### PR TITLE
Add a "raw" mode in the irydium viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4282,9 +4282,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "bl": {
@@ -4763,14 +4763,14 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4795,6 +4795,13 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
         },
         "is-number": {
           "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^14.11.1",
     "@types/polka": "^0.5.1",
     "babel-jest": "^26.6.3",
+    "chokidar": "^3.5.1",
     "d3-dag": "^0.6.2",
     "d3-shape": "^2.1.0",
     "eslint": "^7.0.0",

--- a/packages/compiler/src/templates/index.html
+++ b/packages/compiler/src/templates/index.html
@@ -17,12 +17,6 @@
         }
       }
     </style>
-    {{#liveReload}}
-    <script>
-      document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
-      ':35729/livereload.js?snipver=1"></' + 'script>')
-    </script>
-    {{/liveReload}}
     <script id="svelteapp" type="text/plain">
       {{{ svelteJs }}}
     </script>

--- a/packages/viewer/src/components/DocumentView.svelte
+++ b/packages/viewer/src/components/DocumentView.svelte
@@ -3,8 +3,21 @@
   import GraphView from "./GraphView.svelte";
   const { open } = getContext("simple-modal");
 
+  let rawMode;
+
+  let iframe;
+
+  let mdChangeSocket = new WebSocket("ws://localhost:35731");
+  mdChangeSocket.onmessage = function (event) {
+    iframe.contentWindow.location.reload();
+  };
+
   const openGraph = () => {
     open(GraphView);
+  };
+
+  const toggleRaw = () => {
+    rawMode = !rawMode;
   };
 </script>
 
@@ -34,7 +47,10 @@
 <div class="header">
   <div class="buttons">
     <button on:click={openGraph}>Graph</button>
-    <button>Debug</button>
+    <button on:click={toggleRaw}>{rawMode ? 'Normal' : 'Raw'}</button>
   </div>
 </div>
-<iframe title="irydium" src="/iridium" />
+<iframe
+  bind:this={iframe}
+  title="irydium"
+  src={`/iridium${rawMode ? '?raw=1' : ''}`} />


### PR DESCRIPTION
This allows viewing the generated HTML created by irydium in the
viewer -- probably most useful for people working on the irydium
compiler itself, but may also be useful in other debugging scenarios.
