### PR TITLE
Fix `undefined on undefined` error messages

### DIFF
--- a/packages/viewer/src/cli.js
+++ b/packages/viewer/src/cli.js
@@ -90,7 +90,7 @@ polka()
     } catch (err) {
       console.log(err);
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(`${err.type} on line ${err.lineNumber}: ${err.message}`);
+      res.end(err.message);
     }
   })
   .listen(3000, (err) => {


### PR DESCRIPTION
Really we need better, uniform error handling when something
bad happens, but this is at least a minor improvement.
