### PR TITLE
Handle code chunks with curlies in them

### DIFF
--- a/packages/compiler/__tests__/mdToSvx.tests.js
+++ b/packages/compiler/__tests__/mdToSvx.tests.js
@@ -33,3 +33,18 @@ describe("mdToSvx tests", () => {
     ]);
   });
 });
+
+describe("edge cases for input", () => {
+  it("empty code chunk permutations", async () => {
+    // both empty code chunks and code chunks with curly braces
+    // (e.g. ````{code-cell}`) evaluate to empty code cells
+    ["```", "```{code}"].forEach(async (codeChunk) => {
+      const output = await mdToSvx(codeChunk);
+      expect(output.rootComponent.code).toEqual(
+        expect.stringContaining(
+          '<pre class="language-undefined">{@html `<code class="language-undefined"></code>`}</pre>'
+        )
+      );
+    });
+  });
+});

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -1,7 +1,7 @@
 import { mdToSvx } from "./mdToSvx";
 import { svxToHTML } from "./svxToHTML";
 
-export function compile(input, options) {
+export function compile(input, options = {}) {
   return mdToSvx(input).then(
     ({ rootComponent, subComponents, frontMatter }) => {
       return options.mode === "mdsvex"


### PR DESCRIPTION
For example:

```{code}
```

This would break when it came to parsing the output in svelte, because
it would try to take out the value of an undefined `code` variable as
the language for the cell.
