### PR TITLE
Fix standalone compiler command

### DIFF
--- a/packages/compiler/rollup.config.js
+++ b/packages/compiler/rollup.config.js
@@ -32,11 +32,7 @@ export default [
   },
   {
     // the irydium cli
-    plugins: [
-      ...getBaseCompilerPlugins(),
-      resolve({ preferBuiltins: true }),
-      commonjs(),
-    ],
+    plugins: [...getBaseCompilerPlugins(), resolve({ preferBuiltins: true })],
     input: "src/cli.js",
     external: [
       "front-matter",
@@ -53,8 +49,6 @@ export default [
       "unist-util-visit",
       "vfile-message",
     ],
-    output: [
-      { file: "dist/cli.js", format: "cjs", interop: false, sourcemap: false },
-    ],
+    output: [{ file: "dist/cli.js", format: "cjs", sourcemap: false }],
   },
 ];

--- a/packages/compiler/src/cli.js
+++ b/packages/compiler/src/cli.js
@@ -1,5 +1,4 @@
-import { mdToSvx } from "./mdToSvx";
-import { svxToHTML } from "./svxToHTML";
+import { compile } from "./compile";
 
 const fs = require("fs");
 
@@ -10,10 +9,9 @@ if (args.length !== 1) {
 }
 
 const input = fs.readFileSync(args[0]);
-mdToSvx(input)
-  .then((svx) => svxToHTML(svx))
+compile(input)
   .then((output) => console.log(output.html))
   .catch((err) => {
-    console.log(err);
+    console.error(err);
     process.exit(1);
   });

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -2,14 +2,11 @@ import { mdToSvx } from "./mdToSvx";
 import { svxToHTML } from "./svxToHTML";
 
 export function compile(input, options = {}) {
-  return mdToSvx(input)
-    .then(({ rootComponent, subComponents, frontMatter }) => {
+  return mdToSvx(input).then(
+    ({ rootComponent, subComponents, frontMatter }) => {
       return options.mode === "mdsvex"
         ? { html: rootComponent.code, frontMatter }
         : svxToHTML(rootComponent, subComponents, frontMatter, options);
-    })
-    .catch((err) => {
-      console.error(err);
-      throw err;
-    });
+    }
+  );
 }


### PR DESCRIPTION
Also: don't have compile() itself catch errors (and rethrow). Leave
that up to the consumer.
