### PR TITLE
A few fixes to the viewer application for npm

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "bin": {
-    "irmd-viewer": "bin/irmd-compile"
+    "irmd-viewer": "bin/irmd-viewer"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,6 @@
     "url": "https://github.com/irydium/irydium/issues"
   },
   "dependencies": {
-    "@irydium/compiler": "file:../compiler",
     "livereload": "^0.9.1",
     "polka": "next"
   }


### PR DESCRIPTION
* viewer does not actually depend on compiler (currently)
* use correct name for viewer application
