### PR TITLE
MyST admonitions

### DIFF
--- a/packages/compiler/compiler-plugins.js
+++ b/packages/compiler/compiler-plugins.js
@@ -4,15 +4,17 @@ export function createTemplates(baseDir) {
   const dirname = baseDir || __dirname;
 
   const fs = require("fs");
-  return ["templates/index.html", "templates/tasks.js", "taskrunner.js"].reduce(
-    (acc, filename) => {
-      return {
-        ...acc,
-        [filename]: fs.readFileSync(`${dirname}/src/${filename}`, "utf8"),
-      };
-    },
-    {}
-  );
+  return [
+    "templates/Admonition.svelte",
+    "templates/index.html",
+    "templates/tasks.js",
+    "taskrunner.js",
+  ].reduce((acc, filename) => {
+    return {
+      ...acc,
+      [filename]: fs.readFileSync(`${dirname}/src/${filename}`, "utf8"),
+    };
+  }, {});
 }
 
 export const getBaseCompilerPlugins = (baseDir = ".") => {

--- a/packages/compiler/src/svxToHTML.js
+++ b/packages/compiler/src/svxToHTML.js
@@ -4,7 +4,11 @@ import mustache from "mustache";
 import * as rollup from "rollup/dist/es/rollup.browser.js";
 import fetch from "cross-fetch";
 
-import { bundleIndexSource, taskRunnerSource } from "./templates";
+import {
+  admonitionSource,
+  bundleIndexSource,
+  taskRunnerSource,
+} from "./templates";
 
 const CDN_URL = "https://cdn.jsdelivr.net/npm";
 
@@ -104,6 +108,7 @@ export async function svxToHTML(
 ) {
   const files = new Map([
     ["./mdsvelte.svelte", mdSvelte],
+    ["./Admonition.svelte", { code: admonitionSource, map: "" }],
     [
       "./taskrunner",
       {
@@ -113,7 +118,6 @@ export async function svxToHTML(
     ],
     ...svelteComponents,
   ]);
-
   const svelteJs = await createSvelteBundle(files);
   return {
     html: mustache.render(bundleIndexSource, {

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -10,8 +10,14 @@ if (!Object.keys(__TEMPLATES).length) {
   __TEMPLATES = templatePlugin.createTemplates();
 }
 
+const admonitionSource = __TEMPLATES["templates/Admonition.svelte"];
 const bundleIndexSource = __TEMPLATES["templates/index.html"];
 const taskScriptSource = __TEMPLATES["templates/tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
 
-export { bundleIndexSource, taskScriptSource, taskRunnerSource };
+export {
+  admonitionSource,
+  bundleIndexSource,
+  taskScriptSource,
+  taskRunnerSource,
+};

--- a/packages/compiler/src/templates/Admonition.svelte
+++ b/packages/compiler/src/templates/Admonition.svelte
@@ -1,0 +1,57 @@
+<script>
+  export let type = "";
+  let title = type[0].toUpperCase() + type.substr(1);
+  let symbol;
+
+  if (type === "note") symbol = "ℹ️";
+  else if (type === "warning") symbol = "⚠️";
+</script>
+
+<style>
+  .admonition {
+    margin: 1.5625em auto;
+    padding: 0 0.6rem 0.8rem !important;
+    overflow: hidden;
+    page-break-inside: avoid;
+    border-left: 0.2rem solid;
+    border-left-color: currentcolor;
+    border-left-color: rgba(var(--pst-color-admonition-default), 1);
+    border-bottom-color: rgba(var(--pst-color-admonition-default), 1);
+    border-right-color: rgba(var(--pst-color-admonition-default), 1);
+    border-top-color: rgba(var(--pst-color-admonition-default), 1);
+    border-radius: 0.1rem;
+    box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
+      0 0 0.05rem rgba(0, 0, 0, 0.1);
+    transition: color 0.25s, background-color 0.25s, border-color 0.25s;
+  }
+
+  .admonition.note {
+    /* border-left-color: var(--color-admonition-title--note); */
+    border-left-color: #00b0ff;
+  }
+
+  .admonition.warning {
+    /* border-left-color: var(--color-admonition-title--note); */
+    border-left-color: #ff9100;
+  }
+
+  .admonition-title {
+    position: relative;
+    margin: 0 -0.75rem 0.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+    font-weight: 500;
+  }
+
+  .admonition-title.note {
+    background-color: rgba(0, 176, 255, 0.1);
+  }
+
+  .admonition-title.warning {
+    background-color: rgba(255, 145, 0, 0.1);
+  }
+</style>
+
+<div class="admonition {type}">
+  <p class="admonition-title {type}">{symbol ? symbol + ' ' : ''}{title}</p>
+  <slot />
+</div>

--- a/packages/site/src/examples/myst-support.md
+++ b/packages/site/src/examples/myst-support.md
@@ -1,0 +1,15 @@
+# MyST markdown primitives
+
+In addition to code cells, Irydium provides the note and warning directives from the [myst markdown format].
+Support for more directives is tracked in [irydium/irydium#123].
+
+```{note}
+This is an exciting note!
+```
+
+```{warning}
+This is a warning! It means be careful!
+```
+
+[myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
+[irydium/irydium#123]: https://github.com/irydium/irydium/issues/123

--- a/packages/site/src/routes/examples.svelte
+++ b/packages/site/src/routes/examples.svelte
@@ -5,10 +5,12 @@
   import ffxData from "../examples/firefox-public-data.md";
   import gcpBurndown from "../examples/gcp-burndown.md";
   import pyodide from "../examples/pyodide.md";
+  import mystSupport from "../examples/myst-support.md";
 
   let examples = [
     { content: intro, title: "Introduction" },
     { content: pyodide, title: "Using Python" },
+    { content: mystSupport, title: "MyST Directives" },
     { content: gcpBurndown, title: "GCP Burndown" },
     { content: ffxData, title: "Firefox Data Report" },
   ];
@@ -23,6 +25,33 @@
     editor.updateMd(md); // pass through updated state to codemirror
   }
 </script>
+
+<svelte:head>
+  <title>Examples</title>
+</svelte:head>
+
+<div class="body">
+  <section class="example-list">
+    <ul>
+      {#each examples as example}
+        <li>
+          <span
+            aria-current={example.title === selectedExample.title
+              ? "example"
+              : undefined}
+            on:click={() => updateSelected(example)}>{example.title}</span
+          >
+        </li>
+      {/each}
+    </ul>
+  </section>
+  <section>
+    <Editor bind:this={editor} bind:md />
+  </section>
+  <section>
+    <Output {md} />
+  </section>
+</div>
 
 <style>
   .body {
@@ -65,27 +94,3 @@
     bottom: -1px;
   }
 </style>
-
-<svelte:head>
-  <title>Examples</title>
-</svelte:head>
-
-<div class="body">
-  <section class="example-list">
-    <ul>
-      {#each examples as example}
-        <li>
-          <span
-            aria-current={example.title === selectedExample.title ? 'example' : undefined}
-            on:click={() => updateSelected(example)}>{example.title}</span>
-        </li>
-      {/each}
-    </ul>
-  </section>
-  <section>
-    <Editor bind:this={editor} bind:md />
-  </section>
-  <section>
-    <Output {md} />
-  </section>
-</div>


### PR DESCRIPTION
Support the "note" and "warning" admonition types from MyST:

https://jupyterbook.org/content/myst.html

This isn't quite *proper* support, since the MyST specification
allows for specifying markdown (or any other content) inside the
admonition. But it's an interesting start.
