### PR TITLE
Open links in irydium documents in new tab

### DIFF
--- a/packages/compiler/src/templates/index.html
+++ b/packages/compiler/src/templates/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>{{ title }}</title>
+    <base target="_blank" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.css"


### PR DESCRIPTION
Debatable whether this is *always* the right choice, but it's definitely
right for the examples page. Maybe we can make this configurable later.