### PR TITLE
wrong route for importing plotly component

### DIFF
--- a/packages/site/static/examples/pyodide.md
+++ b/packages/site/static/examples/pyodide.md
@@ -1,7 +1,7 @@
 ---
 title: Irydium ❤️ Python
 imports:
-  - /examples/plotlyjs.md#Plotly
+  - /components/plotlyjs.md#Plotly
 ---
 
 # {title}


### PR DESCRIPTION
Fixed import location for components