### PR TITLE
Fix hover-effect in document list

### DIFF
--- a/packages/site/src/components/DocumentList.svelte
+++ b/packages/site/src/components/DocumentList.svelte
@@ -81,11 +81,11 @@
 
   .document-list li {
     padding: 8px 8px 8px 16px;
-    cursor: pointer;
   }
 
   .document-list a {
     text-decoration: none;
+    cursor: pointer;
   }
 
   [aria-current] {


### PR DESCRIPTION
Make only the links (not the surrounding) have `cursor: pointer`
attached. Before it would appear that you could click on a link when
you actually couldn't.