### PR TITLE
Add "anonymous" CellResults

### DIFF
--- a/packages/compiler/compiler-plugins.js
+++ b/packages/compiler/compiler-plugins.js
@@ -11,6 +11,7 @@ export function createTemplates(baseDir) {
   return [
     "../../site/static/components/python.md",
     "templates/Admonition.svelte",
+    "templates/CellResults.svelte",
     "templates/index.html",
     "templates/tasks.js",
     "taskrunner.js",

--- a/packages/compiler/src/parseMd.js
+++ b/packages/compiler/src/parseMd.js
@@ -54,6 +54,8 @@ export default async function extractCode(input, topLevel = true) {
 
   const tree = unified().use(markdown).parse(input);
 
+  let unlabeledIdCounter = 0;
+
   visit(tree, ["code"], (node) => {
     // process and extract myst directives
     if (node.lang && node.lang.startsWith("{") && node.lang.endsWith("}")) {
@@ -67,9 +69,8 @@ export default async function extractCode(input, topLevel = true) {
         const nodeContent = fm(node.value);
 
         if (!nodeContent.attributes.id) {
-          throw new Error(
-            `Code chunk defined without id (line: ${node.position.start.line})`
-          );
+          // cells without an identifier get rendered directly in the document
+          nodeContent.attributes.id = `__cell${unlabeledIdCounter++}`;
         }
 
         // svelte cells are parsed kind of specially

--- a/packages/compiler/src/svelteToHTML.js
+++ b/packages/compiler/src/svelteToHTML.js
@@ -6,6 +6,7 @@ import fetch from "cross-fetch";
 
 import {
   admonitionSource,
+  cellResultsSource,
   bundleIndexSource,
   taskRunnerSource,
 } from "./templates";
@@ -109,6 +110,7 @@ export async function svelteToHTML(
   const files = new Map([
     ["./mdsvelte.svelte", mdSvelte],
     ["./Admonition.svelte", { code: admonitionSource, map: "" }],
+    ["./CellResults.svelte", { code: cellResultsSource, map: "" }],
     [
       "./taskrunner",
       {

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -11,6 +11,7 @@ if (!Object.keys(__TEMPLATES).length) {
 }
 
 const admonitionSource = __TEMPLATES["Admonition.svelte"];
+const cellResultsSource = __TEMPLATES["CellResults.svelte"];
 const bundleIndexSource = __TEMPLATES["index.html"];
 const taskScriptSource = __TEMPLATES["tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
@@ -18,6 +19,7 @@ const pythonPluginSource = __TEMPLATES["python.md"];
 
 export {
   admonitionSource,
+  cellResultsSource,
   bundleIndexSource,
   taskScriptSource,
   taskRunnerSource,

--- a/packages/compiler/src/templates/CellResults.svelte
+++ b/packages/compiler/src/templates/CellResults.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { onMount } from "svelte";
+
+  export let value;
+  let container;
+  onMount(() => {
+    let domNode;
+    if (value instanceof Element) {
+      domNode = value;
+    } else {
+      domNode = document.createElement("div");
+      domNode.innerHTML = JSON.stringify(value);
+    }
+    container.appendChild(domNode);
+  });
+</script>
+
+<div bind:this={container} />

--- a/packages/site/src/routes/examples.svelte
+++ b/packages/site/src/routes/examples.svelte
@@ -8,11 +8,13 @@
   import gcpBurndown from "../../static/examples/gcp-burndown.md";
   import pyodide from "../../static/examples/pyodide.md";
   import mystSupport from "../../static/examples/myst-support.md";
+  import observablePlot from "../../static/examples/observable-plot.md";
 
   const examples = [
     { content: intro, title: "Introduction" },
     { content: pyodide, title: "Using Python" },
     { content: mystSupport, title: "MyST Directives" },
+    { content: observablePlot, title: "Observable Plot" },
     { content: gcpBurndown, title: "GCP Burndown" },
     { content: ffxData, title: "Firefox Data Report" },
   ].map((ex) => ({ ...ex, id: kebabCase(ex.title.toLowerCase()) }));

--- a/packages/site/static/examples/observable-plot.md
+++ b/packages/site/static/examples/observable-plot.md
@@ -1,0 +1,53 @@
+---
+scripts:
+  - https://d3js.org/d3-dsv.v1.min.js
+  - https://cdn.jsdelivr.net/npm/d3@6
+  - https://cdn.jsdelivr.net/npm/@observablehq/plot@0.1
+data:
+  - big_mac_csv: https://raw.githubusercontent.com/TheEconomist/big-mac-data/master/output-data/big-mac-adjusted-index.csv
+---
+
+# Using Observable Plot
+
+You can use [Observable Plot] to create interactive visualizations.
+This has the advantage of being able to render directly in a code cell, as is the case with [Observable].
+In the case, we'll visualize a couple of entries from the Economist's [Big Mac Index].
+
+## Preparing the data
+
+We'll use d3.csvParse, as in other examples.
+
+```{code-cell} js
+---
+id: "big_mac"
+inputs: [ "big_mac_csv" ]
+inline: true
+---
+return d3.csvParse(await big_mac_csv.text(), d3.autoType);
+```
+
+## Rendering the data
+
+Let's use a simple line plot.
+
+```{code-cell} js
+---
+inputs: [big_mac]
+inline: true
+---
+const countryFilter = (d) => ["Canada", "China", "United States"].includes(d.name);
+
+return Plot.plot({
+  y: { grid: true },
+  width: 800,
+  marginRight: 80,
+  marks: [
+    Plot.line(big_mac, {filter: countryFilter, x: "date", y: "dollar_price", stroke: "name" }),
+    Plot.text(big_mac, Plot.selectLast({filter: countryFilter, x: "date", y: "dollar_price", z: "name", text: "name", textAnchor: "start", dx: 3}))
+  ]
+});
+```
+
+[observable plot]: https://github.com/observablehq/plot
+[observable]: https://observablehq.com/@observablehq
+[big mac index]: https://en.wikipedia.org/wiki/Big_Mac_Index


### PR DESCRIPTION
Anonymous cells simply render their output, rather than storing it in an id. Most immediately, this allows us to support Observable Plot without jumping through a lot of hoops (new example!). But it also opens the door to more direct support for Python-based data visualization using libraries like matplotlib and altair.

