### PR TITLE
Myst panels

### DIFF
--- a/packages/compiler/compiler-plugins.js
+++ b/packages/compiler/compiler-plugins.js
@@ -12,6 +12,7 @@ export function createTemplates(baseDir) {
     "../../site/static/components/python.md",
     "templates/Admonition.svelte",
     "templates/CellResults.svelte",
+    "templates/Panels.svelte",
     "templates/index.html",
     "templates/tasks.js",
     "taskrunner.js",

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -67,8 +67,9 @@ export const processMyst = () => {
         } else if (mystType === "panels") {
           let newNode = {
             type: "html",
-            value: `<Panels>${node.value}</Panels>`,
+            value: `<Panels panelContents={"${node.value}"}/>`,
           };
+          console.log("panels node value: ", node.value);
           parent.children[index] = newNode;
           return index;
         } else {

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -67,9 +67,9 @@ export const processMyst = () => {
         } else if (mystType === "panels") {
           let newNode = {
             type: "html",
-            value: `<Panels panelContents={"${node.value}"}/>`,
+            value: `<Panels panelContents=${node}/>`,
           };
-          console.log("panels node value: ", node.value);
+          console.log(node);
           parent.children[index] = newNode;
           return index;
         } else {

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -67,7 +67,7 @@ export const processMyst = () => {
         } else if (mystType === "panels") {
           let newNode = {
             type: "html",
-            value: `<Panels panelContents=${node}/>`,
+            value: `<Panels value={"${node.value}"}/>`,
           };
           console.log(node);
           parent.children[index] = newNode;

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -64,6 +64,13 @@ export const processMyst = () => {
           };
           parent.children[index] = newNode;
           return index;
+        } else if (mystType === "panels") {
+          let newNode = {
+            type: "html",
+            value: `<Panels>${node.value}</Panels>`,
+          };
+          parent.children[index] = newNode;
+          return index;
         } else {
           // the "language" of this code cell is something we don't yet support
           // (e.g. one of the many things in MyST that we don't handle) -- convert
@@ -221,6 +228,7 @@ export const augmentSvx = ({ codeCells, scripts, frontMatter }) => {
           .join("\n") +
         'import Admonition from "./Admonition.svelte";\n' +
         'import CellResults from "./CellResults.svelte";\n' +
+        'import Panels from "./Panels.svelte";\n' +
         mustache.render(taskScriptSource, {
           taskVariables: tasks
             .map((task) => task.id)

--- a/packages/compiler/src/svelteToHTML.js
+++ b/packages/compiler/src/svelteToHTML.js
@@ -7,6 +7,7 @@ import fetch from "cross-fetch";
 import {
   admonitionSource,
   cellResultsSource,
+  panelsSource,
   bundleIndexSource,
   taskRunnerSource,
 } from "./templates";
@@ -111,6 +112,7 @@ export async function svelteToHTML(
     ["./mdsvelte.svelte", mdSvelte],
     ["./Admonition.svelte", { code: admonitionSource, map: "" }],
     ["./CellResults.svelte", { code: cellResultsSource, map: "" }],
+    ["./Panels.svelte", {code: panelsSource, map: ""}],
     [
       "./taskrunner",
       {

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -12,6 +12,7 @@ if (!Object.keys(__TEMPLATES).length) {
 
 const admonitionSource = __TEMPLATES["Admonition.svelte"];
 const cellResultsSource = __TEMPLATES["CellResults.svelte"];
+const panelsSource = __TEMPLATES["Panels.svelte"];
 const bundleIndexSource = __TEMPLATES["index.html"];
 const taskScriptSource = __TEMPLATES["tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
@@ -20,6 +21,7 @@ const pythonPluginSource = __TEMPLATES["python.md"];
 export {
   admonitionSource,
   cellResultsSource,
+  panelsSource,
   bundleIndexSource,
   taskScriptSource,
   taskRunnerSource,

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,5 +1,19 @@
 <script>
+  import { onMount } from "svelte";
+  const contents = "Test --- Test2";
+  let cards = [];
 
+  onMount(() => {
+    if (contents !== "") {
+      cards = parsePanels(contents);
+    }
+  })
+
+  function parsePanels (contents) {
+    const panelDelimiterRegex = /\-{3,}/;
+    const cards = contents.split(panelDelimiterRegex);
+    return cards;
+  }
 </script>
 
 <style>
@@ -8,5 +22,10 @@
 
 <div class="container">
   <div class="row">
+    {#each cards as card, i}
+      <ul>
+        <li>{card}</li>
+      </ul>
+    {/each}
   </div>
 </div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,0 +1,12 @@
+<script>
+
+</script>
+
+<style>
+
+</style>
+
+<div class="container">
+  <div class="row">
+  </div>
+</div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -2,9 +2,13 @@
   import { onMount } from "svelte";
   const contents = "Test\n---\nTest2";
   export let panelContents;
-  let literalContents;
   let cards = [];
   let reactiveCards = [];
+  let value;
+
+  $: ({ value } = panelContents);
+
+  console.log(value);
 
   onMount(() => {
     if (contents !== "") {
@@ -18,11 +22,6 @@
     return cards;
   }
 
-  $: literalContents = `${panelContents}`;
-
-  /* $: reactiveCards = parsePanels(panelContents); */
-
-  /* $: console.log(reactiveCards); */
 </script>
 
 <style>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,18 +1,15 @@
 <script>
   import { onMount } from "svelte";
   const contents = "Test\n---\nTest2";
-  export let panelContents;
+  export let value = "";
   let cards = [];
   let reactiveCards = [];
-  let value;
 
-  $: ({ value } = panelContents);
-
-  console.log(value);
+  $: console.log(value);
 
   onMount(() => {
     if (contents !== "") {
-      cards = parsePanels(contents);
+      cards = parsePanels(value);
     }
   })
 

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,7 +1,10 @@
 <script>
   import { onMount } from "svelte";
-  const contents = "Test --- Test2";
+  const contents = "Test\n---\nTest2";
+  export let panelContents;
+  let literalContents;
   let cards = [];
+  let reactiveCards = [];
 
   onMount(() => {
     if (contents !== "") {
@@ -10,10 +13,16 @@
   })
 
   function parsePanels (contents) {
-    const panelDelimiterRegex = /\-{3,}/;
+    const panelDelimiterRegex = /\n\-{3,}\n/;
     const cards = contents.split(panelDelimiterRegex);
     return cards;
   }
+
+  $: literalContents = `${panelContents}`;
+
+  /* $: reactiveCards = parsePanels(panelContents); */
+
+  /* $: console.log(reactiveCards); */
 </script>
 
 <style>
@@ -22,6 +31,7 @@
 
 <div class="container">
   <div class="row">
+    <div></div>
     {#each cards as card, i}
       <ul>
         <li>{card}</li>

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -12,6 +12,7 @@ This is a warning! It means be careful!
 ```
 
 ```{panels}
+Test\n---\nTest
 ```
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -11,5 +11,7 @@ This is an exciting note!
 This is a warning! It means be careful!
 ```
 
+```{panels}
+```
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123


### PR DESCRIPTION
First attempt at #200 to support MyST Panels.

Currently panels are rendered as a hardcoded unordered list in ```/packages/compiler/src/templates/Panels.svelte```.


Passing ```(node.value)``` from ```/packages/compiler/src/plugins.js``` to ```/packages/compiler/src/templates/Panels.svelte```as a prop results in an ```Unterminated string literal``` error when dynamically editing MyST Support example in the dev site.