### PR TITLE
Myst panels

### DIFF
--- a/packages/compiler/compiler-plugins.js
+++ b/packages/compiler/compiler-plugins.js
@@ -11,6 +11,7 @@ export function createTemplates(baseDir) {
   return [
     "../../site/static/components/python.md",
     "templates/Admonition.svelte",
+    "templates/Panels.svelte",
     "templates/CellResults.svelte",
     "templates/index.html",
     "templates/tasks.js",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -28,6 +28,7 @@
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.21",
     "mdsvex": "^0.9.7",
+    "micromark": "^3.0.5",
     "mustache": "^4.0.1",
     "rollup": "^2.33.3",
     "svelte": "^3.30.0",

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -67,6 +67,15 @@ export const processMyst = () => {
           };
           parent.children[index] = newNode;
           return index;
+        } else if (mystType ==="panels") {
+          let panels = parsePanels(node.value);
+          // parse each card
+          let newNode = {
+            type: "html",
+            value: `Thing`
+          }
+          parent.children[index] = newNode;
+          return index;
         } else {
           // the "language" of this code cell is something we don't yet support
           // (e.g. one of the many things in MyST that we don't handle) -- convert
@@ -79,6 +88,41 @@ export const processMyst = () => {
     });
   };
 };
+
+function parsePanels (contents) {
+  const panelDelimiterRegex = /\n\-{3,}\n/;
+  const headerDelimiterRegex = /\n\^{3,}\n/;
+  const footerDelimiterRegex = /\n\+{3,}\n/;
+
+  // first retrieve cards
+  const cards = contents.split(panelDelimiterRegex);
+
+  // retrieve header and footer if exists
+  for (const card of cards) {
+    // default empty string for now
+    let header = "";
+    let body = card;
+    let footer = "";
+    let contents;
+
+    if (headerDelimiterRegex.test(body)) {
+      contents = body.split(headerDelimiterRegex)
+      if (contents.length == 2) {
+        [header, body]  = contents
+      } else {console.log("Invalid syntax for panel header.")}
+    }
+    if (footerDelimiterRegex.test(body)) {
+      contents = body.split(footerDelimiterRegex)
+      if (contents.length == 2) {
+        [body, footer]  = body.split(footerDelimiterRegex)
+      } else {console.log("Invalid syntax for panel footer.")}
+    }
+    console.log("header: ", header);
+    console.log("body: ", body);
+    console.log("footer: ", footer);
+  }
+  return;
+}
 
 function createJSTask(id, code, inputs = []) {
   return {
@@ -223,6 +267,7 @@ export const augmentSvx = ({ codeCells, scripts, frontMatter }) => {
           )
           .join("\n") +
         'import Admonition from "./Admonition.svelte";\n' +
+        'import Panels from "./Panels.svelte";\n' +
         'import CellResults from "./CellResults.svelte";\n' +
         mustache.render(taskScriptSource, {
           taskVariables: tasks

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -1,5 +1,6 @@
 import fm from "front-matter";
 import mustache from "mustache";
+import { micromark } from "micromark";
 import { TASK_TYPE, TASK_STATE } from "./taskrunner";
 import { visit } from "unist-util-visit";
 import { parse as svelteParse } from "svelte/compiler";
@@ -60,7 +61,9 @@ export const processMyst = () => {
           // a note! we want to replace the code chunk with a svelte component
           let newNode = {
             type: "html",
-            value: `<Admonition type={"${mystType}"}>${node.value}</Admonition>`,
+            value: `<Admonition type={"${mystType}"}>${micromark(
+              node.value
+            )}</Admonition>`,
           };
           parent.children[index] = newNode;
           return index;

--- a/packages/compiler/src/plugins.js
+++ b/packages/compiler/src/plugins.js
@@ -68,11 +68,17 @@ export const processMyst = () => {
           parent.children[index] = newNode;
           return index;
         } else if (mystType ==="panels") {
-          let panels = parsePanels(node.value);
+          let cards = parsePanels(node.value);
           // parse each card
           let newNode = {
             type: "html",
-            value: `Thing`
+            value: `<Panels>
+                    <ul>
+                    {#each ${cards} as card}
+                    <li>card</li>
+                    {/each}
+                    </ul>
+                   </Panels>`
           }
           parent.children[index] = newNode;
           return index;
@@ -96,6 +102,7 @@ function parsePanels (contents) {
 
   // first retrieve cards
   const cards = contents.split(panelDelimiterRegex);
+  let bodies = [];
 
   // retrieve header and footer if exists
   for (const card of cards) {
@@ -109,19 +116,26 @@ function parsePanels (contents) {
       contents = body.split(headerDelimiterRegex)
       if (contents.length == 2) {
         [header, body]  = contents
-      } else {console.log("Invalid syntax for panel header.")}
+      } else {
+        console.log("Invalid syntax for panel header.");
+        return;
+      }
     }
     if (footerDelimiterRegex.test(body)) {
       contents = body.split(footerDelimiterRegex)
       if (contents.length == 2) {
         [body, footer]  = body.split(footerDelimiterRegex)
-      } else {console.log("Invalid syntax for panel footer.")}
+      } else {
+        console.log("Invalid syntax for panel footer.");
+        return;
+      }
     }
-    console.log("header: ", header);
-    console.log("body: ", body);
-    console.log("footer: ", footer);
+    // console.log("header: ", header);
+    // console.log("body: ", body);
+    // console.log("footer: ", footer);
+    bodies.push(body);
   }
-  return;
+  return bodies;
 }
 
 function createJSTask(id, code, inputs = []) {

--- a/packages/compiler/src/svelteToHTML.js
+++ b/packages/compiler/src/svelteToHTML.js
@@ -7,6 +7,7 @@ import fetch from "cross-fetch";
 import {
   admonitionSource,
   cellResultsSource,
+  panelsSource,
   bundleIndexSource,
   taskRunnerSource,
 } from "./templates";
@@ -110,6 +111,7 @@ export async function svelteToHTML(
   const files = new Map([
     ["./mdsvelte.svelte", mdSvelte],
     ["./Admonition.svelte", { code: admonitionSource, map: "" }],
+    ["./Panels.svelte", { code: panelsSource, map: ""}],
     ["./CellResults.svelte", { code: cellResultsSource, map: "" }],
     [
       "./taskrunner",

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -12,6 +12,7 @@ if (!Object.keys(__TEMPLATES).length) {
 
 const admonitionSource = __TEMPLATES["Admonition.svelte"];
 const cellResultsSource = __TEMPLATES["CellResults.svelte"];
+const panelsSource = __TEMPLATES["Panels.svelte"];
 const bundleIndexSource = __TEMPLATES["index.html"];
 const taskScriptSource = __TEMPLATES["tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
@@ -20,6 +21,7 @@ const pythonPluginSource = __TEMPLATES["python.md"];
 export {
   admonitionSource,
   cellResultsSource,
+  panelsSource,
   bundleIndexSource,
   taskScriptSource,
   taskRunnerSource,

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,0 +1,13 @@
+<script>
+  const contents = "Test\n---\nTest2";
+  /* export const cards=[]; */
+</script>
+
+<style>
+</style>
+
+<div class="container">
+  <div class="row">
+    `${contents}`
+  </div>
+</div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,6 +1,16 @@
 <script>
-  const contents = "Test\n---\nTest2";
-  /* export const cards=[]; */
+  import { onMount, afterUpdate } from 'svelte';
+  const contents = ["test", "test2"];
+  export let cards=[];
+
+  onMount(async () => {
+    console.log(cards);
+  });
+
+  afterUpdate(async () => {
+    console.log(cards);
+  });
+
 </script>
 
 <style>
@@ -8,6 +18,6 @@
 
 <div class="container">
   <div class="row">
-    `${contents}`
+    <slot></slot>
   </div>
 </div>

--- a/packages/site/static/examples/gcp-burndown.md
+++ b/packages/site/static/examples/gcp-burndown.md
@@ -13,6 +13,14 @@ data:
 
 # {title}
 
+```{note}
+This is a reproduction of an [Iodide notebook](https://alpha.iodide.io/notebooks/3593/)
+which was used to track the progress of an internal effort to migrate Mozilla's data
+platform from AWS to GCP in 2019.
+
+The project has long since been completed.
+```
+
 ## Overall progress
 
 <Plotly data={allBugs} />

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -11,5 +11,22 @@ This is an exciting note!
 This is a warning! It means be careful!
 ```
 
+```{panels}
+This is a header
+^^^
+This is a body
++++
+This is a footer
+---
+This is a new panel with no header or footer
+---
+Header
+^^^
+This is a panel with only a header and body
+---
+This is a panel with only a body and footer
++++
+Footer
+```
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,7 @@ importers:
       js-yaml: ^4.0.0
       lodash: ^4.17.21
       mdsvex: ^0.9.7
+      micromark: ^3.0.5
       mustache: ^4.0.1
       rollup: ^2.33.3
       svelte: ^3.30.0
@@ -160,6 +161,7 @@ importers:
       js-yaml: 4.1.0
       lodash: 4.17.21
       mdsvex: 0.9.8_svelte@3.42.1
+      micromark: 3.0.5
       mustache: 4.2.0
       rollup: 2.56.2
       svelte: 3.42.1
@@ -1866,6 +1868,12 @@ packages:
       '@types/node': 16.6.1
     dev: true
 
+  /@types/debug/4.1.7:
+    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+    dependencies:
+      '@types/ms': 0.7.31
+    dev: false
+
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
@@ -1926,6 +1934,10 @@ packages:
   /@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
     dev: true
+
+  /@types/ms/0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: false
 
   /@types/node/16.6.1:
     resolution: {integrity: sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==}
@@ -2643,13 +2655,25 @@ packages:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
     dev: true
 
+  /character-entities-legacy/2.0.0:
+    resolution: {integrity: sha512-YwaEtEvWLpFa6Wh3uVLrvirA/ahr9fki/NUd/Bd4OR6EdJ8D22hovYQEOUCBfQfcqnC4IAMGMsHXY1eXgL4ZZA==}
+    dev: false
+
   /character-entities/1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
     dev: true
 
+  /character-entities/2.0.0:
+    resolution: {integrity: sha512-oHqMj3eAuJ77/P5PaIRcqk+C3hdfNwyCD2DAUcD5gyXkegAuF2USC40CEqPscDk4I8FRGMTojGJQkXDsN5QlJA==}
+    dev: false
+
   /character-reference-invalid/1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: true
+
+  /character-reference-invalid/2.0.0:
+    resolution: {integrity: sha512-pE3Z15lLRxDzWJy7bBHBopRwfI20sbrMVLQTC7xsPglCHf4Wv1e167OgYAFP78co2XlhojDyAqA+IAJse27//g==}
+    dev: false
 
   /chokidar/3.5.2:
     resolution: {integrity: sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==}
@@ -2955,7 +2979,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decimal.js/10.3.1:
     resolution: {integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==}
@@ -3928,12 +3951,23 @@ packages:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
     dev: true
 
+  /is-alphabetical/2.0.0:
+    resolution: {integrity: sha512-5OV8Toyq3oh4eq6sbWTYzlGdnMT/DPI5I0zxUBxjiigQsZycpkKF3kskkao3JyYGuYDHvhgJF+DrjMQp9SX86w==}
+    dev: false
+
   /is-alphanumerical/1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
     dev: true
+
+  /is-alphanumerical/2.0.0:
+    resolution: {integrity: sha512-t+2GlJ+hO9yagJ+jU3+HSh80VKvz/3cG2cxbGGm4S0hjKuhWQXgPVUVOZz3tqZzMjhmphZ+1TIJTlRZRoe6GCQ==}
+    dependencies:
+      is-alphabetical: 2.0.0
+      is-decimal: 2.0.0
+    dev: false
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
@@ -3992,6 +4026,10 @@ packages:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
     dev: true
 
+  /is-decimal/2.0.0:
+    resolution: {integrity: sha512-QfrfjQV0LjoWQ1K1XSoEZkTAzSa14RKVMa5zg3SdAfzEmQzRM4+tbSFWb78creCeA9rNBzaZal92opi1TwPWZw==}
+    dev: false
+
   /is-extglob/2.1.1:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
     engines: {node: '>=0.10.0'}
@@ -4015,6 +4053,10 @@ packages:
   /is-hexadecimal/1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
     dev: true
+
+  /is-hexadecimal/2.0.0:
+    resolution: {integrity: sha512-vGOtYkiaxwIiR0+Ng/zNId+ZZehGfINwTzdrDqc6iubbnQWhnPuYymOzOKUDqa2cSl59yHnEh2h6MvRLQsyNug==}
+    dev: false
 
   /is-module/1.0.0:
     resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
@@ -4978,6 +5020,145 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /micromark-core-commonmark/1.0.1:
+    resolution: {integrity: sha512-vEOw8hcQ3nwHkKKNIyP9wBi8M50zjNajtmI+cCUWcVfJS+v5/3WCh4PLKf7PPRZFUutjzl4ZjlHwBWUKfb/SkA==}
+    dependencies:
+      micromark-factory-destination: 1.0.0
+      micromark-factory-label: 1.0.0
+      micromark-factory-space: 1.0.0
+      micromark-factory-title: 1.0.0
+      micromark-factory-whitespace: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-html-tag-name: 1.0.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-subtokenize: 1.0.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+      parse-entities: 3.0.0
+    dev: false
+
+  /micromark-factory-destination/1.0.0:
+    resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-factory-label/1.0.0:
+    resolution: {integrity: sha512-XWEucVZb+qBCe2jmlOnWr6sWSY6NHx+wtpgYFsm4G+dufOf6tTQRRo0bdO7XSlGPu5fyjpJenth6Ksnc5Mwfww==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-factory-space/1.0.0:
+    resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-factory-title/1.0.0:
+    resolution: {integrity: sha512-flvC7Gx0dWVWorXuBl09Cr3wB5FTuYec8pMGVySIp2ZlqTcIjN/lFohZcP0EG//krTptm34kozHk7aK/CleCfA==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-factory-whitespace/1.0.0:
+    resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-character/1.1.0:
+    resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
+    dependencies:
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-chunked/1.0.0:
+    resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
+    dependencies:
+      micromark-util-symbol: 1.0.0
+    dev: false
+
+  /micromark-util-classify-character/1.0.0:
+    resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-combine-extensions/1.0.0:
+    resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-decode-numeric-character-reference/1.0.0:
+    resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
+    dependencies:
+      micromark-util-symbol: 1.0.0
+    dev: false
+
+  /micromark-util-encode/1.0.0:
+    resolution: {integrity: sha512-cJpFVM768h6zkd8qJ1LNRrITfY4gwFt+tziPcIf71Ui8yFzY9wG3snZQqiWVq93PG4Sw6YOtcNiKJfVIs9qfGg==}
+    dev: false
+
+  /micromark-util-html-tag-name/1.0.0:
+    resolution: {integrity: sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g==}
+    dev: false
+
+  /micromark-util-normalize-identifier/1.0.0:
+    resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
+    dependencies:
+      micromark-util-symbol: 1.0.0
+    dev: false
+
+  /micromark-util-resolve-all/1.0.0:
+    resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
+    dependencies:
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-sanitize-uri/1.0.0:
+    resolution: {integrity: sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-encode: 1.0.0
+      micromark-util-symbol: 1.0.0
+    dev: false
+
+  /micromark-util-subtokenize/1.0.0:
+    resolution: {integrity: sha512-EsnG2qscmcN5XhkqQBZni/4oQbLFjz9yk3ZM/P8a3YUjwV6+6On2wehr1ALx0MxK3+XXXLTzuBKHDFeDFYRdgQ==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+    dev: false
+
+  /micromark-util-symbol/1.0.0:
+    resolution: {integrity: sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ==}
+    dev: false
+
+  /micromark-util-types/1.0.1:
+    resolution: {integrity: sha512-UT0ylWEEy80RFYzK9pEaugTqaxoD/j0Y9WhHpSyitxd99zjoQz7JJ+iKuhPAgOW2MiPSUAx+c09dcqokeyaROA==}
+    dev: false
+
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
@@ -4986,6 +5167,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /micromark/3.0.5:
+    resolution: {integrity: sha512-QfjERBnPw0G9mxhOCkkbRP0n8SX8lIBLrEKeEVceviUukqVMv3hWE4AgNTOK/W6GWqtPvvIHg2Apl3j1Dxm6aQ==}
+    dependencies:
+      '@types/debug': 4.1.7
+      debug: 4.3.2
+      micromark-core-commonmark: 1.0.1
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-encode: 1.0.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-subtokenize: 1.0.0
+      micromark-util-symbol: 1.0.0
+      micromark-util-types: 1.0.1
+      parse-entities: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
@@ -5056,7 +5260,6 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5312,6 +5515,17 @@ packages:
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
     dev: true
+
+  /parse-entities/3.0.0:
+    resolution: {integrity: sha512-AJlcIFDNPEP33KyJLguv0xJc83BNvjxwpuUIcetyXUsLpVXAUCePJ5kIoYtEN2R1ac0cYaRu/vk9dVFkewHQhQ==}
+    dependencies:
+      character-entities: 2.0.0
+      character-entities-legacy: 2.0.0
+      character-reference-invalid: 2.0.0
+      is-alphanumerical: 2.0.0
+      is-decimal: 2.0.0
+      is-hexadecimal: 2.0.0
+    dev: false
 
   /parse-json/4.0.0:
     resolution: {integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=}


### PR DESCRIPTION
- Created helper function for parsing panels (error logic could be cleaner if invalid syntax provided, i.e. 2 headers for a single panel card)
- allowable syntax for newNode.value is unclear, able to pass simple single string to slots, but unable to include more complex loop logic (eventually Panel will contain a variable number of Card components, Card components need ```{header, body, footer}``` props -- named slots?).
- Current error in repl (http://localhost:3000/examples#myst-directives) is "Expected as". Is there a better way to display which line where the repl errors are coming from?