### PR TITLE
Myst panels

### DIFF
--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,0 +1,42 @@
+import { parsePanels } from "../src/myst.ts";
+
+function createPanel() {
+  let panel = `\`\`\`{panels}\n`;
+  const card1 = createCard("body", "header", "footer");
+  const card2 = createCard("body");
+  const card3 = createCard("body", footer="footer");
+  const cards = [card1, card2, card3];
+  for (var i = 0; i < cards.length; i++) {
+    panel = panel.concat(cards[i])
+    if (cards.indexOf(cards[i]) !== cards.length - 1) {
+    panel = panel.concat("\n---\n")
+    }
+  }
+  return panel;
+}
+function createCard(body, header, footer) {
+  if (header && footer) {
+    return (`${header}\n^^^\n${body}\n+++\n${footer}`)
+  }
+  else if (footer) {
+    return (`${body}\n+++\n${footer}`)
+  }
+  else if (header) {
+    return (`${header}\n^^^\n${body}`)
+  }
+  else {
+    return (`${body}`)
+  }
+}
+
+describe("create basic panel", () => {
+  it("should create a panel with three cards", async () => {
+    expect(
+      await parsePanels(createPanel())
+    ).toEqual(
+      [{"header": "header", "body": "body", "footer": "footer"},
+       {"body": "body"},
+       {"body": "body", "footer": "footer"}]
+    )
+  })
+})

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,4 +1,4 @@
-import { parsePanels } from "../src/myst.ts";
+import { parsePanel } from "../src/myst.ts";
 
 function createPanel() {
   let panel = `\`\`\`{panels}\n`;
@@ -27,7 +27,7 @@ function createCard(body, header, footer) {
 
 describe("create basic panel", () => {
   it("should create a panel with two cards", async () => {
-    expect(await parsePanels(createPanel())).toEqual([
+    expect(await parsePanel(createPanel())).toEqual([
       { header: "header", body: "body", footer: "footer" },
       { body: "body" },
     ]);

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,36 +1,80 @@
 import { parsePanel } from "../src/myst.ts";
 
-function createPanel() {
+function createPanel(cardArray) {
   let panel = ``;
-  const card1 = createCard("body", "header", "footer");
-  const card2 = createCard("body");
-  const cards = [card1, card2];
-  for (var i = 0; i < cards.length; i++) {
-    panel = panel.concat(cards[i]);
-    if (cards.indexOf(cards[i]) !== cards.length - 1) {
+  for (const card of cardArray) {
+    const createdCard = createCard(card);
+    panel = panel.concat(createdCard);
+    if (cardArray.indexOf(card) !== cardArray.length - 1) {
       panel = panel.concat("\n---\n");
     }
   }
   return panel;
 }
 
-function createCard(body, header, footer) {
-  if (header && footer) {
-    return `${header}\n^^^\n${body}\n+++\n${footer}`;
-  } else if (footer) {
-    return `${body}\n+++\n${footer}`;
-  } else if (header) {
-    return `${header}\n^^^\n${body}`;
+function createCard(cardObj) {
+  if (cardObj.header && cardObj.footer) {
+    return `${cardObj.header}\n^^^\n${cardObj.body}\n+++\n${cardObj.footer}`;
+  } else if (cardObj.footer) {
+    return `${cardObj.body}\n+++\n${cardObj.footer}`;
+  } else if (cardObj.header) {
+    return `${cardObj.header}\n^^^\n${cardObj.body}`;
   } else {
-    return `${body}`;
+    return `${cardObj.body}`;
   }
 }
 
-describe("create basic panel", () => {
+describe("create different panel types successfully", () => {
+  it("should create a panel with a single header card", async () => {
+    expect(
+      await parsePanel(createPanel([{ body: "body", header: "header" }]))
+    ).toEqual([{ header: "header", body: "body" }]);
+  });
+
+  it("should create a panel with a header card", async () => {
+    expect(
+      await parsePanel(createPanel([{ body: "body", footer: "footer" }]))
+    ).toEqual([{ footer: "footer", body: "body" }]);
+  });
+
+  it("should create a panel with a header card", async () => {
+    expect(
+      await parsePanel(
+        createPanel([{ body: "body", header: "header", footer: "footer" }])
+      )
+    ).toEqual([{ header: "header", body: "body", footer: "footer" }]);
+  });
+
+  it("should create a panel with a body card", async () => {
+    expect(await parsePanel(createPanel([{ body: "body" }]))).toEqual([
+      { body: "body" },
+    ]);
+  });
+
   it("should create a panel with two cards", async () => {
-    expect(await parsePanel(createPanel())).toEqual([
+    expect(
+      await parsePanel(
+        createPanel([
+          { body: "body", header: "header", footer: "footer" },
+          { body: "body" },
+        ])
+      )
+    ).toEqual([
       { header: "header", body: "body", footer: "footer" },
       { body: "body" },
     ]);
+  });
+});
+
+describe("create panel with malformed duplicate panel properties", () => {
+  it("should raise an error for a panel with a malformed double header", () => {
+    expect(() => {
+      parsePanel("header\n^^^\nheader2\n^^^\nbody");
+    }).toThrow(`Invalid syntax for MyST panel card header`);
+  });
+  it("should raise an error for a panel with a malformed double footer", () => {
+    expect(() => {
+      parsePanel("body\n+++\nfooter\n+++\nfooter2");
+    }).toThrow(`Invalid syntax for MyST panel card footer.`);
   });
 });

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -13,6 +13,7 @@ function createPanel() {
   }
   return panel;
 }
+
 function createCard(body, header, footer) {
   if (header && footer) {
     return `${header}\n^^^\n${body}\n+++\n${footer}`;

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,7 +1,7 @@
 import { parsePanel } from "../src/myst.ts";
 
 function createPanel() {
-  let panel;
+  let panel = ``;
   const card1 = createCard("body", "header", "footer");
   const card2 = createCard("body");
   const cards = [card1, card2];

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -4,39 +4,32 @@ function createPanel() {
   let panel = `\`\`\`{panels}\n`;
   const card1 = createCard("body", "header", "footer");
   const card2 = createCard("body");
-  const card3 = createCard("body", footer="footer");
-  const cards = [card1, card2, card3];
+  const cards = [card1, card2];
   for (var i = 0; i < cards.length; i++) {
-    panel = panel.concat(cards[i])
+    panel = panel.concat(cards[i]);
     if (cards.indexOf(cards[i]) !== cards.length - 1) {
-    panel = panel.concat("\n---\n")
+      panel = panel.concat("\n---\n");
     }
   }
   return panel;
 }
 function createCard(body, header, footer) {
   if (header && footer) {
-    return (`${header}\n^^^\n${body}\n+++\n${footer}`)
-  }
-  else if (footer) {
-    return (`${body}\n+++\n${footer}`)
-  }
-  else if (header) {
-    return (`${header}\n^^^\n${body}`)
-  }
-  else {
-    return (`${body}`)
+    return `${header}\n^^^\n${body}\n+++\n${footer}`;
+  } else if (footer) {
+    return `${body}\n+++\n${footer}`;
+  } else if (header) {
+    return `${header}\n^^^\n${body}`;
+  } else {
+    return `${body}`;
   }
 }
 
 describe("create basic panel", () => {
-  it("should create a panel with three cards", async () => {
-    expect(
-      await parsePanels(createPanel())
-    ).toEqual(
-      [{"header": "header", "body": "body", "footer": "footer"},
-       {"body": "body"},
-       {"body": "body", "footer": "footer"}]
-    )
-  })
-})
+  it("should create a panel with two cards", async () => {
+    expect(await parsePanels(createPanel())).toEqual([
+      { header: "header", body: "body", footer: "footer" },
+      { body: "body" },
+    ]);
+  });
+});

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,7 +1,7 @@
 import { parsePanel } from "../src/myst.ts";
 
 function createPanel() {
-  let panel = `\`\`\`{panels}\n`;
+  let panel;
   const card1 = createCard("body", "header", "footer");
   const card2 = createCard("body");
   const cards = [card1, card2];

--- a/packages/compiler/src/create-templates.js
+++ b/packages/compiler/src/create-templates.js
@@ -8,6 +8,7 @@ export function createTemplates(baseDir) {
     "../../site/static/components/python.md",
     "templates/Admonition.svelte",
     "templates/Panels.svelte",
+    "templates/Card.svelte",
     "templates/CellResults.svelte",
     "templates/index.html",
     "templates/tasks.js",

--- a/packages/compiler/src/create-templates.js
+++ b/packages/compiler/src/create-templates.js
@@ -7,6 +7,7 @@ export function createTemplates(baseDir) {
   return [
     "../../site/static/components/python.md",
     "templates/Admonition.svelte",
+    "templates/Panels.svelte",
     "templates/CellResults.svelte",
     "templates/index.html",
     "templates/tasks.js",

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,6 +1,6 @@
-import type { MystPanel } from "./types";
+import type { MystCard } from "./types";
 
-export function parsePanels(contents: string): Array<MystPanel> {
+export function parsePanel(contents: string): Array<MystCard> {
   const panelDelimiterRegex = /\n-{3,}\n/;
   const headerDelimiterRegex = /\n\^{3,}\n/;
   const footerDelimiterRegex = /\n\+{3,}\n/;
@@ -22,7 +22,7 @@ export function parsePanels(contents: string): Array<MystPanel> {
       if (contents.length == 2) {
         [header, body]  = contents
       } else {
-        throw new Error(`Invalid syntax for MyST panel header.`);
+        throw new Error(`Invalid syntax for MyST panel card header.`);
       }
     }
     if (footerDelimiterRegex.test(body)) {
@@ -30,7 +30,7 @@ export function parsePanels(contents: string): Array<MystPanel> {
       if (contents.length == 2) {
         [body, footer]  = body.split(footerDelimiterRegex)
       } else {
-        throw new Error(`Invalid syntax for MyST panel footer.`);
+        throw new Error(`Invalid syntax for MyST panel card footer.`);
       }
     }
     splitCards.push({'header': header, 'body': body, 'footer': footer});

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,14 +1,13 @@
-import { micromark } from "micromark";
 import type { MystPanel } from "./types";
 
 export function parsePanels(contents: string): Array<MystPanel> {
-  const panelDelimiterRegex = /\n\-{3,}\n/;
+  const panelDelimiterRegex = /\n-{3,}\n/;
   const headerDelimiterRegex = /\n\^{3,}\n/;
   const footerDelimiterRegex = /\n\+{3,}\n/;
 
   // first retrieve cards
   const cards = contents.split(panelDelimiterRegex);
-  let splitCards = [];
+  const splitCards = [];
 
   // retrieve header and footer if exists
   for (const card of cards) {

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -11,15 +11,12 @@ export function parsePanel(contents: string): Array<MystCard> {
 
   // retrieve header and footer if exists
   for (const card of cards) {
-    // default empty string
-    let header = "";
+    let header, footer;
     let body = card;
-    let footer = "";
-    let contents;
 
     const parsedCard = { body: body } as MystCard;
     if (headerDelimiterRegex.test(body)) {
-      contents = body.split(headerDelimiterRegex);
+      const contents = body.split(headerDelimiterRegex);
       if (contents.length == 2) {
         [header, body] = contents;
         parsedCard.header = header;
@@ -28,7 +25,7 @@ export function parsePanel(contents: string): Array<MystCard> {
       }
     }
     if (footerDelimiterRegex.test(body)) {
-      contents = body.split(footerDelimiterRegex);
+      const contents = body.split(footerDelimiterRegex);
       if (contents.length == 2) {
         [body, footer] = body.split(footerDelimiterRegex);
         parsedCard.footer = footer;

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -17,20 +17,20 @@ export function parsePanel(contents: string): Array<MystCard> {
     let footer = "";
     let contents;
 
-    const parsedCard = {'body': body} as MystCard;
+    const parsedCard = { body: body } as MystCard;
     if (headerDelimiterRegex.test(body)) {
-      contents = body.split(headerDelimiterRegex)
+      contents = body.split(headerDelimiterRegex);
       if (contents.length == 2) {
-        [header, body]  = contents;
+        [header, body] = contents;
         parsedCard.header = header;
       } else {
         throw new Error(`Invalid syntax for MyST panel card header.`);
       }
     }
     if (footerDelimiterRegex.test(body)) {
-      contents = body.split(footerDelimiterRegex)
+      contents = body.split(footerDelimiterRegex);
       if (contents.length == 2) {
-        [body, footer]  = body.split(footerDelimiterRegex)
+        [body, footer] = body.split(footerDelimiterRegex);
         parsedCard.footer = footer;
       } else {
         throw new Error(`Invalid syntax for MyST panel card footer.`);

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,3 +1,5 @@
+import { micromark } from "micromark";
+
 export function parsePanels (contents) {
    const panelDelimiterRegex = /\n\-{3,}\n/;
   const headerDelimiterRegex = /\n\^{3,}\n/;
@@ -33,7 +35,7 @@ export function parsePanels (contents) {
         return;
       }
     }
-    splitCards.push({'header': header, 'body': body, 'footer': footer});
+    splitCards.push({'header': micromark(header), 'body': micromark(body), 'footer': micromark(footer)});
   }
   return {'cards': splitCards};
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -17,10 +17,12 @@ export function parsePanel(contents: string): Array<MystCard> {
     let footer = "";
     let contents;
 
+    const parsedCard = {'body': body} as MystCard;
     if (headerDelimiterRegex.test(body)) {
       contents = body.split(headerDelimiterRegex)
       if (contents.length == 2) {
-        [header, body]  = contents
+        [header, body]  = contents;
+        parsedCard.header = header;
       } else {
         throw new Error(`Invalid syntax for MyST panel card header.`);
       }
@@ -29,11 +31,13 @@ export function parsePanel(contents: string): Array<MystCard> {
       contents = body.split(footerDelimiterRegex)
       if (contents.length == 2) {
         [body, footer]  = body.split(footerDelimiterRegex)
+        parsedCard.footer = footer;
       } else {
         throw new Error(`Invalid syntax for MyST panel card footer.`);
       }
     }
-    splitCards.push({'header': header, 'body': body, 'footer': footer});
+    parsedCard.body = body;
+    splitCards.push(parsedCard);
   }
   return splitCards;
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,0 +1,39 @@
+export function parsePanels (contents) {
+   const panelDelimiterRegex = /\n\-{3,}\n/;
+  const headerDelimiterRegex = /\n\^{3,}\n/;
+  const footerDelimiterRegex = /\n\+{3,}\n/;
+
+  // first retrieve cards
+  const cards = contents.split(panelDelimiterRegex);
+  let splitCards = [];
+
+  // retrieve header and footer if exists
+  for (const card of cards) {
+    // default empty string
+    let header = "";
+    let body = card;
+    let footer = "";
+    let contents;
+
+    if (headerDelimiterRegex.test(body)) {
+      contents = body.split(headerDelimiterRegex)
+      if (contents.length == 2) {
+        [header, body]  = contents
+      } else {
+        console.log("Invalid syntax for panel header.");
+        return;
+      }
+    }
+    if (footerDelimiterRegex.test(body)) {
+      contents = body.split(footerDelimiterRegex)
+      if (contents.length == 2) {
+        [body, footer]  = body.split(footerDelimiterRegex)
+      } else {
+        console.log("Invalid syntax for panel footer.");
+        return;
+      }
+    }
+    splitCards.push({'header': header, 'body': body, 'footer': footer});
+  }
+  return {'cards': splitCards};
+}

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,7 +1,8 @@
 import { micromark } from "micromark";
+import type { MystPanel } from "./types";
 
-export function parsePanels (contents) {
-   const panelDelimiterRegex = /\n\-{3,}\n/;
+export function parsePanels(contents: string): Array<MystPanel> {
+  const panelDelimiterRegex = /\n\-{3,}\n/;
   const headerDelimiterRegex = /\n\^{3,}\n/;
   const footerDelimiterRegex = /\n\+{3,}\n/;
 
@@ -22,8 +23,7 @@ export function parsePanels (contents) {
       if (contents.length == 2) {
         [header, body]  = contents
       } else {
-        console.log("Invalid syntax for panel header.");
-        return;
+        throw new Error(`Invalid syntax for MyST panel header.`);
       }
     }
     if (footerDelimiterRegex.test(body)) {
@@ -31,11 +31,10 @@ export function parsePanels (contents) {
       if (contents.length == 2) {
         [body, footer]  = body.split(footerDelimiterRegex)
       } else {
-        console.log("Invalid syntax for panel footer.");
-        return;
+        throw new Error(`Invalid syntax for MyST panel footer.`);
       }
     }
-    splitCards.push({'header': micromark(header), 'body': micromark(body), 'footer': micromark(footer)});
+    splitCards.push({'header': header, 'body': body, 'footer': footer});
   }
-  return {'cards': splitCards};
+  return splitCards;
 }

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -98,15 +98,19 @@ export const processMyst = () => {
               `<Panels>
                {{#cards}}
                <Card>
+               {{#header}}
                <div slot="header">
                {{{header}}}
                </div>
+               {{/header}}
                <div slot="body">
                {{{body}}}
                </div>
+               {{#footer}}
                <div slot="footer">
                {{{footer}}}
                </div>
+               {{/footer}}
                </Card>
                {{/cards}}
                </Panels>`,

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -88,6 +88,7 @@ export const processMyst = () => {
             }
             return card;
           });
+          // create dummy object to access array properties with mustache
           const cards = {'cards': htmlCards};
           // parse each card
           const newNode = {
@@ -96,9 +97,17 @@ export const processMyst = () => {
               `<Panels>
                <div>
                {{#cards}}
+               <Card>
+               <div slot="header">
                {{{header}}}
+               </div>
+               <div slot="body">
                {{{body}}}
+               </div>
+               <div slot="footer">
                {{{footer}}}
+               </div>
+               </Card>
                {{/cards}}
                </div>
                </Panels>`,
@@ -276,6 +285,7 @@ export const augmentSvx = ({
           .join("\n") +
         'import Admonition from "./Admonition.svelte";\n' +
         'import Panels from "./Panels.svelte";\n' +
+        'import Card from "./Card.svelte";\n' +
         'import CellResults from "./CellResults.svelte";\n' +
         mustache.render(taskScriptSource, {
           taskVariables: tasks

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -79,7 +79,7 @@ export const processMyst = () => {
           (parent as Parent).children[index] = newNode;
           return index;
         } else if (mystType === "panels") {
-          let cards = {'cards': parsePanels(value)};
+          const cards = {'cards': parsePanels(value)};
           console.log(cards);
           // parse each card
           const newNode = {

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -86,16 +86,13 @@ export const processMyst = () => {
             type: "html",
             value: mustache.render(
               `<Panels>
-               <ul>
+               <div>
                {{#cards}}
-               <li>Card </li>
-               <ul>
-               <li>{{header}}</li>
-               <li>{{body}}</li>
-               <li>{{footer}}</li>
-               </ul>
+               {{header}}
+               {{body}}
+               {{footer}}
                {{/cards}}
-               </ul>
+               </div>
                </Panels>`,
               cards
             ),

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -89,7 +89,6 @@ export const processMyst = () => {
             return card;
           });
           const cards = {'cards': htmlCards};
-          console.log(cards);
           // parse each card
           const newNode = {
             type: "html",
@@ -97,7 +96,6 @@ export const processMyst = () => {
               `<Panels>
                <div>
                {{#cards}}
-               {{{{header}}}
                {{{header}}}
                {{{body}}}
                {{{footer}}}

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -12,7 +12,7 @@ import type {
   CodeNodeAttributes,
   ParsedDocument,
   ScriptNode,
-  MystCard
+  MystCard,
 } from "./types";
 
 // remark plugin: extracts `{code-cell}` and other MyST chunks, removing them from the
@@ -89,8 +89,7 @@ export const processMyst = () => {
             return card;
           });
           // create dummy object to access array properties with mustache
-          const cards = {'cards': htmlCards};
-          console.log(cards);
+          const cards = { cards: htmlCards };
           // parse each card
           const newNode = {
             type: "html",

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -79,7 +79,7 @@ export const processMyst = () => {
           (parent as Parent).children[index] = newNode;
           return index;
         } else if (mystType === "panels") {
-          let cards = parsePanels(value);
+          let cards = {'cards': parsePanels(value)};
           console.log(cards);
           // parse each card
           const newNode = {

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -90,12 +90,12 @@ export const processMyst = () => {
           });
           // create dummy object to access array properties with mustache
           const cards = {'cards': htmlCards};
+          console.log(cards);
           // parse each card
           const newNode = {
             type: "html",
             value: mustache.render(
               `<Panels>
-               <div>
                {{#cards}}
                <Card>
                <div slot="header">
@@ -109,7 +109,6 @@ export const processMyst = () => {
                </div>
                </Card>
                {{/cards}}
-               </div>
                </Panels>`,
               cards
             ),

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -81,8 +81,8 @@ export const processMyst = () => {
           return index;
         } else if (mystType === "panels") {
           const mdCards = parsePanel(value);
-          let k: keyof typeof MystCard;
-          let htmlCards = mdCards.map((card) => {
+          const htmlCards = mdCards.map((card: MystCard) => {
+            let k: keyof MystCard;
             for (k in card) {
               card[k] = micromark(card[k]);
             }

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -5,6 +5,7 @@ import { TASK_TYPE, TASK_STATE } from "./taskrunner";
 import { Node, Parent, visit } from "unist-util-visit";
 import { parse as svelteParse } from "svelte/compiler";
 
+import { parsePanels } from "./myst";
 import { taskScriptSource } from "./templates";
 import type {
   CodeNode,
@@ -74,6 +75,30 @@ export const processMyst = () => {
             value: `<Admonition type={"${mystType}"}>${micromark(
               value
             )}</Admonition>`,
+          };
+          (parent as Parent).children[index] = newNode;
+          return index;
+        } else if (mystType === "panels") {
+          let cards = parsePanels(value);
+          console.log(cards);
+          // parse each card
+          const newNode = {
+            type: "html",
+            value: mustache.render(
+              `<Panels>
+               <ul>
+               {{#cards}}
+               <li>Card </li>
+               <ul>
+               <li>{{header}}</li>
+               <li>{{body}}</li>
+               <li>{{footer}}</li>
+               </ul>
+               {{/cards}}
+               </ul>
+               </Panels>`,
+              cards
+            ),
           };
           (parent as Parent).children[index] = newNode;
           return index;
@@ -245,6 +270,7 @@ export const augmentSvx = ({
           })
           .join("\n") +
         'import Admonition from "./Admonition.svelte";\n' +
+        'import Panels from "./Panels.svelte";\n' +
         'import CellResults from "./CellResults.svelte";\n' +
         mustache.render(taskScriptSource, {
           taskVariables: tasks

--- a/packages/compiler/src/svelteToHTML.ts
+++ b/packages/compiler/src/svelteToHTML.ts
@@ -7,6 +7,7 @@ import fetch from "cross-fetch";
 import {
   admonitionSource,
   panelsSource,
+  cardSource,
   cellResultsSource,
   bundleIndexSource,
   taskRunnerSource,
@@ -121,8 +122,8 @@ export async function svelteToHTML(
     ["./mdsvelte.svelte", mdSvelte],
     ["./Admonition.svelte", { code: admonitionSource, map: "" }],
     ["./Panels.svelte", {code: panelsSource, map: ""}],
+    ["./Card.svelte", {code: cardSource, map: ""}],
     ["./CellResults.svelte", { code: cellResultsSource, map: "" }],
-
     [
       "./taskrunner",
       {

--- a/packages/compiler/src/svelteToHTML.ts
+++ b/packages/compiler/src/svelteToHTML.ts
@@ -6,6 +6,7 @@ import fetch from "cross-fetch";
 
 import {
   admonitionSource,
+  panelsSource,
   cellResultsSource,
   bundleIndexSource,
   taskRunnerSource,
@@ -119,7 +120,9 @@ export async function svelteToHTML(
   const files = new Map([
     ["./mdsvelte.svelte", mdSvelte],
     ["./Admonition.svelte", { code: admonitionSource, map: "" }],
+    ["./Panels.svelte", {code: panelsSource, map: ""}],
     ["./CellResults.svelte", { code: cellResultsSource, map: "" }],
+
     [
       "./taskrunner",
       {

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -12,6 +12,7 @@ if (!Object.keys(__TEMPLATES).length) {
 
 const admonitionSource = __TEMPLATES["Admonition.svelte"];
 const cellResultsSource = __TEMPLATES["CellResults.svelte"];
+const panelsSource = __TEMPLATES["Panels.svelte"];
 const bundleIndexSource = __TEMPLATES["index.html"];
 const taskScriptSource = __TEMPLATES["tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
@@ -20,6 +21,7 @@ const pythonPluginSource = __TEMPLATES["python.md"];
 export {
   admonitionSource,
   cellResultsSource,
+  panelsSource,
   bundleIndexSource,
   taskScriptSource,
   taskRunnerSource,

--- a/packages/compiler/src/templates.js
+++ b/packages/compiler/src/templates.js
@@ -13,6 +13,7 @@ if (!Object.keys(__TEMPLATES).length) {
 const admonitionSource = __TEMPLATES["Admonition.svelte"];
 const cellResultsSource = __TEMPLATES["CellResults.svelte"];
 const panelsSource = __TEMPLATES["Panels.svelte"];
+const cardSource = __TEMPLATES["Card.svelte"];
 const bundleIndexSource = __TEMPLATES["index.html"];
 const taskScriptSource = __TEMPLATES["tasks.js"];
 const taskRunnerSource = __TEMPLATES["taskrunner.js"];
@@ -22,6 +23,7 @@ export {
   admonitionSource,
   cellResultsSource,
   panelsSource,
+  cardSource,
   bundleIndexSource,
   taskScriptSource,
   taskRunnerSource,

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,0 +1,11 @@
+<script>
+</script>
+
+<style>
+</style>
+
+<div class="card">
+  <slot name="header"></slot>
+  <slot name="body"></slot>
+  <slot name="footer"></slot>
+</div>

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -36,21 +36,9 @@
 	  padding: .75rem 1.25rem;
   }
 
-  .col-4 {
-	  flex: 0 0 33.33333%;
-	  max-width: 33.33333%;
-	  position: relative;
-	  width: 100%;
-	  padding-right: 15px;
-	  padding-left: 15px;
-  }
-
-  .d-flex {
-	  display: flex !important;
-  }
-
 </style>
-<div class="d-flex col-4">
+
+<div>
   <div class="card">
     {#if $$slots.header}
     <div class="card-header">

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -2,10 +2,68 @@
 </script>
 
 <style>
-</style>
+  .card {
+	  background-clip: border-box;
+	  background-color: #fff;
+	  border: 1px solid rgba(0,0,0,0.125);
+	  border-radius: .25rem;
+	  display: -ms-flexbox;
+	  display: flex;
+	  -ms-flex-direction: column;
+	  flex-direction: column;
+	  min-width: 0;
+	  position: relative;
+	  word-wrap: break-word;
+  }
 
-<div class="card">
-  <slot name="header"></slot>
-  <slot name="body"></slot>
-  <slot name="footer"></slot>
+  .card-header {
+	  background-color: rgba(0,0,0,0.03);
+	  border-bottom: 1px solid rgba(0,0,0,0.125);
+	  margin-bottom: 0;
+	  padding: .75rem 1.25rem;
+  }
+
+  .card-body {
+	  -ms-flex: 1 1 auto;
+	  flex: 1 1 auto;
+	  min-height: 1px;
+	  padding: 1.25rem;
+  }
+
+  .card-footer {
+	  background-color: rgba(0,0,0,0.03);
+	  border-top: 1px solid rgba(0,0,0,0.125);
+	  padding: .75rem 1.25rem;
+  }
+
+  .col-4 {
+	  flex: 0 0 33.33333%;
+	  max-width: 33.33333%;
+	  position: relative;
+	  width: 100%;
+	  padding-right: 15px;
+	  padding-left: 15px;
+  }
+
+  .d-flex {
+	  display: flex !important;
+  }
+
+</style>
+<div class="d-flex col-4">
+  <div class="card">
+    {#if $$slots.header}
+    <div class="card-header">
+      <slot name="header"></slot>
+    </div>
+    {/if}
+    <div class="card-body">
+      <slot name="body"></slot>
+    </div>
+    {#if $$slots.footer}
+    <div class="card-footer">
+      <slot name="footer"></slot>
+    </div>
+    {/if}
+  </div>
 </div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -2,22 +2,6 @@
  </script>
 
 <style>
-  .container {
-	  margin-left: auto;
-	  margin-right: auto;
-	  padding-left: 15px;
-	  padding-right: 15px;
-	  width: 100%;
-  }
-  .row {
-	  display: -ms-flexbox;
-	  display: flex;
-	  -ms-flex-wrap: wrap;
-	  flex-wrap: wrap;
-	  margin-left: -15px;
-	  margin-right: -15px;
-  }
-
 </style>
 
 <div class="container">

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -2,6 +2,22 @@
  </script>
 
 <style>
+  .container {
+	  margin-left: auto;
+	  margin-right: auto;
+	  padding-left: 15px;
+	  padding-right: 15px;
+	  width: 100%;
+  }
+  .row {
+	  display: -ms-flexbox;
+	  display: flex;
+	  -ms-flex-wrap: wrap;
+	  flex-wrap: wrap;
+	  margin-left: -15px;
+	  margin-right: -15px;
+  }
+
 </style>
 
 <div class="container">

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,0 +1,11 @@
+ <script>
+ </script>
+
+<style>
+</style>
+
+<div class="container">
+  <div class="row">
+    <slot></slot>
+  </div>
+</div>

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -43,6 +43,12 @@ export interface ParsedDocument {
   codeCells: Array<CodeCell>;
 }
 
+export interface MystPanel {
+  header?: string;
+  body: string;
+  footer?: string;
+}
+
 export interface SvelteComponentDefinition {
   code: string;
   map: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -43,7 +43,7 @@ export interface ParsedDocument {
   codeCells: Array<CodeCell>;
 }
 
-export interface MystPanel {
+export interface MystCard {
   header?: string;
   body: string;
   footer?: string;

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -11,6 +11,8 @@ This is an exciting note!
 This is a warning! It means be careful!
 ```
 
+There is also preliminary support for [panels]. Here's one with both a header and a footer:
+
 ```{panels}
 # This is a header
 ^^^
@@ -30,3 +32,4 @@ Footer
 ```
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123
+[panels]: https://jupyterbook.org/content/content-blocks.html#panels

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -12,7 +12,7 @@ This is a warning! It means be careful!
 ```
 
 ```{panels}
-This is a header
+# This is a header
 ^^^
 This is a body
 +++
@@ -20,11 +20,11 @@ This is a footer
 ---
 This is a new panel with no header or footer
 ---
-Header
+# Header
 ^^^
 This is a panel with only a header and body
 ---
-This is a panel with only a body and footer
+This is a panel with only a body and footer.
 +++
 Footer
 ```

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -11,5 +11,22 @@ This is an exciting note!
 This is a warning! It means be careful!
 ```
 
+```{panels}
+This is a header
+^^^
+This is a body
++++
+This is a footer
+---
+This is a new panel with no header or footer
+---
+Header
+^^^
+This is a panel with only a header and body
+---
+This is a panel with only a body and footer
++++
+Footer
+```
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123


### PR DESCRIPTION
Able to pass header, body, footer as separate objects, but micromark not working within mustache.
I tried this syntax:
```
${micromark({{header}})}
```
within mustache.render, but it doesn't look like it can run the micromark function, so I tried to push the micromark function call to ```myst.ts```, which instead gives me string literals within the mustache block.

I also tried out working with named slots using the [svelte repl](https://svelte.dev/repl/9fd7e2cd08844414b2af9a6492f73c1b?version=3.43.0), but am still trying to figure out how conditionals/loops will work with mustache (the current mustache template string deals with Card components, rather than having svelte use ```{#each cards as card}```. 

Having conditional statements at the App level also doesn't seem to work fully, I'd rather have conditional rendering within the ```Card.svelte``` component, depending on whether a header and footer are passed along with a body, but currently it's still styling an empty div rather than omitting it entirely.