### PR TITLE
Take advantage of bootstrap to improve default panel styling

### DIFF
--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,57 +1,18 @@
-<script>
-</script>
-
-<style>
-  .card {
-	  background-clip: border-box;
-	  background-color: #fff;
-	  border: 1px solid rgba(0,0,0,0.125);
-	  border-radius: .25rem;
-	  display: -ms-flexbox;
-	  display: flex;
-	  -ms-flex-direction: column;
-	  flex-direction: column;
-	  min-width: 0;
-	  position: relative;
-	  word-wrap: break-word;
-  }
-
-  .card-header {
-	  background-color: rgba(0,0,0,0.03);
-	  border-bottom: 1px solid rgba(0,0,0,0.125);
-	  margin-bottom: 0;
-	  padding: .75rem 1.25rem;
-  }
-
-  .card-body {
-	  -ms-flex: 1 1 auto;
-	  flex: 1 1 auto;
-	  min-height: 1px;
-	  padding: 1.25rem;
-  }
-
-  .card-footer {
-	  background-color: rgba(0,0,0,0.03);
-	  border-top: 1px solid rgba(0,0,0,0.125);
-	  padding: .75rem 1.25rem;
-  }
-
-</style>
-
-<div>
-  <div class="card">
+<div class="d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2">
+  <div class="card w-100">
     {#if $$slots.header}
-    <div class="card-header">
-      <slot name="header"></slot>
-    </div>
+      <div class="card-header">
+        <slot name="header" />
+      </div>
     {/if}
     <div class="card-body">
-      <slot name="body"></slot>
+      <slot name="body" />
     </div>
+
     {#if $$slots.footer}
-    <div class="card-footer">
-      <slot name="footer"></slot>
-    </div>
+      <div class="card-footer">
+        <slot name="footer" />
+      </div>
     {/if}
   </div>
 </div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,11 +1,5 @@
- <script>
- </script>
-
-<style>
-</style>
-
 <div class="container">
   <div class="row">
-    <slot></slot>
+    <slot />
   </div>
 </div>

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -11,10 +11,10 @@ This is an exciting note!
 This is a warning! It means be careful!
 ```
 
-There is also preliminary support for [panels]. Here's one with both a header and a footer:
+There is also preliminary support for [panels]. Here's a few examples:
 
 ```{panels}
-# This is a header
+This is a header
 ^^^
 This is a body
 +++
@@ -22,7 +22,7 @@ This is a footer
 ---
 This is a new panel with no header or footer
 ---
-# Header
+Header
 ^^^
 This is a panel with only a header and body
 ---
@@ -30,6 +30,7 @@ This is a panel with only a body and footer.
 +++
 Footer
 ```
+
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123
 [panels]: https://jupyterbook.org/content/content-blocks.html#panels


### PR DESCRIPTION
We'll go with the defaults used by JupyterBook (https://jupyterbook.org/content/content-blocks.html#panels)
which in turn uses the Sphinx panel extensions: https://sphinx-panels.readthedocs.io/en/latest/#card-layout
