### PR TITLE
Panel / Card styling for MyST Panels

### DIFF
--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -27,13 +27,13 @@ function createCard(cardObj) {
 describe("create different panel types successfully", () => {
   it("should create a panel with a single header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", header: "header" }]))
+      await parsePanel(createPanel([{ body: "body", header: "header" }])).cards
     ).toEqual([{ header: "header", body: "body" }]);
   });
 
   it("should create a panel with a header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", footer: "footer" }]))
+      await parsePanel(createPanel([{ body: "body", footer: "footer" }])).cards
     ).toEqual([{ footer: "footer", body: "body" }]);
   });
 
@@ -41,12 +41,12 @@ describe("create different panel types successfully", () => {
     expect(
       await parsePanel(
         createPanel([{ body: "body", header: "header", footer: "footer" }])
-      )
+      ).cards
     ).toEqual([{ header: "header", body: "body", footer: "footer" }]);
   });
 
   it("should create a panel with a body card", async () => {
-    expect(await parsePanel(createPanel([{ body: "body" }]))).toEqual([
+    expect(await parsePanel(createPanel([{ body: "body" }])).cards).toEqual([
       { body: "body" },
     ]);
   });
@@ -58,7 +58,7 @@ describe("create different panel types successfully", () => {
           { body: "body", header: "header", footer: "footer" },
           { body: "body" },
         ])
-      )
+      ).cards
     ).toEqual([
       { header: "header", body: "body", footer: "footer" },
       { body: "body" },

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -27,30 +27,32 @@ function createCard(cardObj) {
   }
 }
 
+const defaultStyle = {column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2", card: "w-100"}
+
 describe("create different panel types successfully", () => {
   it("should create a panel with a single header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", header: "header" }])).cards
-    ).toEqual([{ header: "header", body: "body" }]);
+      await parsePanel(createPanel([{ body: "body", header: "header", style: defaultStyle}])).cards
+    ).toEqual([{ header: "header", body: "body", style: defaultStyle}]);
   });
 
   it("should create a panel with a header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", footer: "footer" }])).cards
-    ).toEqual([{ footer: "footer", body: "body" }]);
+      await parsePanel(createPanel([{ body: "body", footer: "footer", style: defaultStyle}])).cards
+    ).toEqual([{ footer: "footer", body: "body", style: defaultStyle }]);
   });
 
   it("should create a panel with a header card", async () => {
     expect(
       await parsePanel(
-        createPanel([{ body: "body", header: "header", footer: "footer" }])
+        createPanel([{ body: "body", header: "header", footer: "footer", style: defaultStyle }])
       ).cards
-    ).toEqual([{ header: "header", body: "body", footer: "footer" }]);
+    ).toEqual([{ header: "header", body: "body", footer: "footer", style: defaultStyle}]);
   });
 
   it("should create a panel with a body card", async () => {
-    expect(await parsePanel(createPanel([{ body: "body" }])).cards).toEqual([
-      { body: "body" },
+    expect(await parsePanel(createPanel([{ body: "body", style: defaultStyle}])).cards).toEqual([
+      { body: "body", style: defaultStyle },
     ]);
   });
 
@@ -58,24 +60,16 @@ describe("create different panel types successfully", () => {
     expect(
       await parsePanel(
         createPanel([
-          { body: "body", header: "header", footer: "footer" },
-          { body: "body" },
+          { body: "body", header: "header", footer: "footer", style: defaultStyle },
+          { body: "body", style: defaultStyle },
         ])
       ).cards
     ).toEqual([
-      { header: "header", body: "body", footer: "footer" },
-      { body: "body" },
+      { header: "header", body: "body", footer: "footer", style: defaultStyle },
+      { body: "body", style: defaultStyle },
     ]);
   });
 });
-
-describe("style panels with Bootstrap default styling", () => {
-  it("should create a panel with classes for bootstrap styling", async () => {
-    expect(await parsePanel(":container: text-center bg-success\n:body: bg-info\n---\nbody").style).toEqual(
-      {container: "text-center bg-success", body: "bg-info"}
-    )
-  })
-})
 
 describe("create panel with malformed duplicate panel properties", () => {
   it("should raise an error for a panel with a malformed double header", () => {

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -9,9 +9,6 @@ function createPanel(cardArray, style) {
       panel = panel.concat("\n---\n");
     }
   }
-  if (style) {
-    panel = { ...panel, style: style };
-  }
   return panel;
 }
 

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -10,7 +10,7 @@ function createPanel(cardArray, style) {
     }
   }
   if (style) {
-    panel = {...panel, style: style}
+    panel = { ...panel, style: style };
   }
   return panel;
 }
@@ -27,40 +27,62 @@ function createCard(cardObj) {
   }
 }
 
-const defaultStyle = {column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2", card: "w-100"}
+const defaultStyle = {
+  column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2",
+  card: "w-100",
+};
 
 describe("create different panel types successfully", () => {
   it("should create a panel with a single header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", header: "header", style: defaultStyle}])).cards
-    ).toEqual([{ header: "header", body: "body", style: defaultStyle}]);
+      await parsePanel(
+        createPanel([{ body: "body", header: "header", style: defaultStyle }])
+      ).cards
+    ).toEqual([{ header: "header", body: "body", style: defaultStyle }]);
   });
 
   it("should create a panel with a header card", async () => {
     expect(
-      await parsePanel(createPanel([{ body: "body", footer: "footer", style: defaultStyle}])).cards
+      await parsePanel(
+        createPanel([{ body: "body", footer: "footer", style: defaultStyle }])
+      ).cards
     ).toEqual([{ footer: "footer", body: "body", style: defaultStyle }]);
   });
 
   it("should create a panel with a header card", async () => {
     expect(
       await parsePanel(
-        createPanel([{ body: "body", header: "header", footer: "footer", style: defaultStyle }])
+        createPanel([
+          {
+            body: "body",
+            header: "header",
+            footer: "footer",
+            style: defaultStyle,
+          },
+        ])
       ).cards
-    ).toEqual([{ header: "header", body: "body", footer: "footer", style: defaultStyle}]);
+    ).toEqual([
+      { header: "header", body: "body", footer: "footer", style: defaultStyle },
+    ]);
   });
 
   it("should create a panel with a body card", async () => {
-    expect(await parsePanel(createPanel([{ body: "body", style: defaultStyle}])).cards).toEqual([
-      { body: "body", style: defaultStyle },
-    ]);
+    expect(
+      await parsePanel(createPanel([{ body: "body", style: defaultStyle }]))
+        .cards
+    ).toEqual([{ body: "body", style: defaultStyle }]);
   });
 
   it("should create a panel with two cards", async () => {
     expect(
       await parsePanel(
         createPanel([
-          { body: "body", header: "header", footer: "footer", style: defaultStyle },
+          {
+            body: "body",
+            header: "header",
+            footer: "footer",
+            style: defaultStyle,
+          },
           { body: "body", style: defaultStyle },
         ])
       ).cards
@@ -81,5 +103,44 @@ describe("create panel with malformed duplicate panel properties", () => {
     expect(() => {
       parsePanel("body\n+++\nfooter\n+++\nfooter2");
     }).toThrow(`Invalid syntax for MyST panel card footer.`);
+  });
+});
+
+describe("create panels with custom Bootstrap styling", () => {
+  it("should create a panel with two cards with the same Bootstrap styles", async () => {
+    expect(
+      await parsePanel(
+        ":body: text-center bg-info\n---\nbody text\n---\nbody 2 text"
+      ).style
+    ).toEqual({
+      ...defaultStyle,
+      body: "text-center bg-info",
+    });
+  });
+  it("should create a panel with two cards with different Bootstrap styles", async () => {
+    expect(
+      await parsePanel(
+        ":body: text-center bg-success\n---\n:body: text-justify bg-info\nbody text\n---\nbody text 2"
+      ).cards.map((card) => card.style)
+    ).toEqual([
+      { ...defaultStyle, body: "text-justify bg-info" },
+      { ...defaultStyle, body: "text-center bg-success" },
+    ]);
+  });
+  it("should create a panel with two cards with overriding column Bootstrap styles", async () => {
+    expect(
+      await parsePanel(
+        ":column: col-lg-4\n---\nbody text\n---\n:column: col-lg-3\nbody text 2"
+      ).cards.map((card) => card.style)
+    ).toEqual([
+      {
+        column: "d-flex col-lg-4 col-md-6 col-sm-6 col-xs-12 p-2",
+        card: "w-100",
+      },
+      {
+        column: "d-flex col-lg-3 col-md-6 col-sm-6 col-xs-12 p-2",
+        card: "w-100",
+      },
+    ]);
   });
 });

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,6 +1,6 @@
 import { parsePanel } from "../src/myst.ts";
 
-function createPanel(cardArray) {
+function createPanel(cardArray, style) {
   let panel = ``;
   for (const card of cardArray) {
     const createdCard = createCard(card);
@@ -8,6 +8,9 @@ function createPanel(cardArray) {
     if (cardArray.indexOf(card) !== cardArray.length - 1) {
       panel = panel.concat("\n---\n");
     }
+  }
+  if (style) {
+    panel = {...panel, style: style}
   }
   return panel;
 }
@@ -65,6 +68,14 @@ describe("create different panel types successfully", () => {
     ]);
   });
 });
+
+describe("style panels with Bootstrap default styling", () => {
+  it("should create a panel with classes for bootstrap styling", async () => {
+    expect(await parsePanel(":container: text-center bg-success\n:body: bg-info\n---\nbody").style).toEqual(
+      {container: "text-center bg-success", body: "bg-info"}
+    )
+  })
+})
 
 describe("create panel with malformed duplicate panel properties", () => {
   it("should raise an error for a panel with a malformed double header", () => {

--- a/packages/compiler/__tests__/myst.tests.js
+++ b/packages/compiler/__tests__/myst.tests.js
@@ -1,6 +1,6 @@
 import { parsePanel } from "../src/myst.ts";
 
-function createPanel(cardArray, style) {
+function createPanel(cardArray) {
   let panel = ``;
   for (const card of cardArray) {
     const createdCard = createCard(card);
@@ -104,13 +104,12 @@ describe("create panel with malformed duplicate panel properties", () => {
 });
 
 describe("create panels with custom Bootstrap styling", () => {
-  it("should create a panel with two cards with the same Bootstrap styles", async () => {
+  it("should create a panel with two cards with the same Bootstrap styles for the panel", async () => {
     expect(
       await parsePanel(
         ":body: text-center bg-info\n---\nbody text\n---\nbody 2 text"
       ).style
     ).toEqual({
-      ...defaultStyle,
       body: "text-center bg-info",
     });
   });

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -19,8 +19,13 @@ export function parsePanel(contents: string): MystPanel {
     const bodyYaml = cardComponents[0];
     let body = cardComponents[1]
     const parsedCard = { body: body } as MystCard;
+    if (panelStyle) {
+      parsedCard.style = panelStyle
+    }
+    // card style will override panel style currently for same prop
     if (bodyYaml.length !== 0) {
-      //parsedCard.style = parseYamlBlock(bodyYaml)
+      const cardStyle = parseYamlBlock(bodyYaml)
+      parsedCard.style = {...parsedCard.style, ...cardStyle}
     }
     if (headerDelimiterRegex.test(body)) {
       const contents = body.split(headerDelimiterRegex);

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -116,7 +116,8 @@ export function mergeStyles(
   const allProps = new Set(
     Object.keys(overridingStyle).concat(Object.keys(initialStyle))
   );
-  for (let k of Array.from(allProps)) {
+  let k: keyof MystStyling
+  for (k of Array.from(allProps)) {
     // Common keys: overridingStyle per key merged over initialStyle
     if (initialStyle[k] !== undefined && overridingStyle[k] !== undefined) {
       const initialPropDict = classesStringToKeyValues(initialStyle[k]);

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -16,10 +16,7 @@ export function parsePanel(contents: string): MystPanel {
   const splitCards: Array<MystCard> = [];
 
   const defaultCardStyle = {column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2",
-                            card: "card w-100",
-                            header: "card-header",
-                            body: "card-body",
-                            footer: "card-footer"
+                            card: "w-100",
                             } as MystStyling
 
   // retrieve header and footer for each card if exists
@@ -64,7 +61,6 @@ export function parsePanel(contents: string): MystPanel {
   if (panelStyle) {
     myPanel = {...myPanel, style: panelStyle}
   }
-  console.log(panelStyle)
   return myPanel
 }
 
@@ -112,13 +108,15 @@ function ltrim(rawString: string) {
 
 export function mergeStyles(panelStyle: MystStyling, cardStyle: MystStyling) : MystStyling {
   let k: keyof MystStyling;
-  for (k in cardStyle) {
-    if (k in panelStyle) {
+  for (k in panelStyle) {
+    if (k in cardStyle) {
       const panelPropDict = classesStringToKeyValues(panelStyle[k]!)
       const cardPropDict = classesStringToKeyValues(cardStyle[k]!)
       // merge Dicts
       const mergedProps = {...panelPropDict, ...cardPropDict}
       cardStyle[k] = propDictToString(mergedProps)
+    } else {
+      cardStyle[k] = panelStyle[k]
     }
   }
   return cardStyle
@@ -129,8 +127,16 @@ export function classesStringToKeyValues(classesString: string) : Record<string,
   let classDictionary = {}
   for (const htmlClass of htmlClasses) {
     const classArray = htmlClass.split('-')
-    const value = classArray.pop()
-    const key = classArray.join('-')
+    let key, value
+    // deal with single prop like "shadow"
+    if (classArray.length === 1) {
+      key = classArray[0]
+      value = '';
+    } 
+    else {
+      value = classArray.pop()
+      key = classArray.join('-')
+    }
     classDictionary = {...classDictionary, [key]: value}
   }
   return classDictionary
@@ -139,7 +145,13 @@ export function classesStringToKeyValues(classesString: string) : Record<string,
 function propDictToString(classObject: Record<string, string>) : string {
   let returnString = ''
   for (const key in classObject) {
-    returnString = returnString + " " + [key, classObject[key]].join("-");
+    let concatValue;
+    if (classObject[key] === '') {
+      concatValue = key
+    } else {
+      concatValue = [key, classObject[key]].join("-")
+    }
+    returnString = returnString + " " + concatValue;
   }
   return ltrim(returnString)
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -9,6 +9,7 @@ export function parsePanel(contents: string): MystPanel {
 
   // get panel styling from beginning of panel if it exists
   const [yamlBlock, panelContents] = parseStyling(contents);
+  const panelStyle = parseYamlBlock(yamlBlock);
   // first retrieve cards
   const cards = panelContents.split(panelDelimiterRegex);
   const splitCards: Array<MystCard> = [];
@@ -19,7 +20,7 @@ export function parsePanel(contents: string): MystPanel {
     let [bodyYaml, body] = parseStyling(card);
     const parsedCard = { body: body } as MystCard;
     if (bodyYaml.length !== 0) {
-      parsedCard.style = bodyYaml;
+      //parsedCard.style = parseYamlBlock(bodyYaml)
     }
     if (headerDelimiterRegex.test(body)) {
       const contents = body.split(headerDelimiterRegex);
@@ -45,7 +46,7 @@ export function parsePanel(contents: string): MystPanel {
 
   let myPanel: MystPanel = {cards: splitCards}
   if (yamlBlock.length !== 0) {
-    myPanel = {...myPanel, style: yamlBlock}
+    myPanel = {...myPanel, style: panelStyle}
   }
   return myPanel
 }
@@ -60,7 +61,7 @@ export function parseStyling(contents: string) {
       if (!ltrim(contentLines[0]).startsWith(":")) {
         break
       } else {
-        yamlLines.push(ltrim(contentLines.shift()!).substring(1))
+        yamlLines.push(ltrim(contentLines.shift()!))
       }
     }
     yamlBlock = yamlLines.join("\n")
@@ -69,6 +70,22 @@ export function parseStyling(contents: string) {
   returnContents = contentLines.join("\n")  
   const returnPanel: [string, string] = [yamlBlock, returnContents]
   return returnPanel
+}
+
+export function parseYamlBlock(yamlBlock: string) {
+  let styleContents = yamlBlock.split("\n")
+  const stylingRegex = /^:([a-z0-9]+):\s*([a-z\s\-0-9]+)/i;
+  // return object with key value pairs
+  let styles = {}
+  for (const line of styleContents) {
+    const stylingArray : RegExpExecArray | null = stylingRegex.exec(line)
+    if (stylingArray && stylingArray.length > 2) {
+      const key : string = stylingArray[1]
+      const value : string = stylingArray[2]
+      styles = {...styles, [key]: value}
+    }
+  }
+  return styles
 }
 
 function ltrim(rawString: string) {

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,19 +1,22 @@
-import type { MystCard } from "./types";
+import type { YieldExpression } from "@babel/types";
+import e from "express";
+import type { MystCard, MystPanelStyling, MystCardStyling } from "./types";
 
 export function parsePanel(contents: string): Array<MystCard> {
   const panelDelimiterRegex = /\n-{3,}\n/;
   const headerDelimiterRegex = /\n\^{3,}\n/;
   const footerDelimiterRegex = /\n\+{3,}\n/;
 
+  // get panel styling from beginning of panel if it exists
+  const panelStyles = parsePanelStyling(contents);
   // first retrieve cards
   const cards = contents.split(panelDelimiterRegex);
   const splitCards = [];
 
-  // retrieve header and footer if exists
+  // retrieve header and footer for each card if exists
   for (const card of cards) {
     let header, footer;
     let body = card;
-
     const parsedCard = { body: body } as MystCard;
     if (headerDelimiterRegex.test(body)) {
       const contents = body.split(headerDelimiterRegex);
@@ -37,4 +40,38 @@ export function parsePanel(contents: string): Array<MystCard> {
     splitCards.push(parsedCard);
   }
   return splitCards;
+}
+
+export function parsePanelStyling(contents: string) {
+  const contentLines = contents.split("\n")
+  // TO ASK: This regex was a PITA. 
+  // Is there a way to get it to do this without having to split contents by newline?
+  const panelStylingRegex = /:[a-z]+:\s[a-z\s\-0-9]+/i;
+  let matchingLines: MystPanelStyling = ({} as any) as MystPanelStyling;
+  // panel styling is only at the beginning of the panels
+  for (let i = 0; i < contentLines.length; i++) {
+    // stop processing lines once individual cards declared
+    if (!contentLines[i].startsWith(":")) {
+      break
+    } else {
+      const valueMatch = contentLines[i].match(panelStylingRegex)
+      if (valueMatch !== null && valueMatch.length === 1) {
+        const splitValues: Array<string> = valueMatch[0].split(": ")
+        if (splitValues.length === 2) {
+          const elementType: string = splitValues[0].substring(1) // remove first :
+          const addtClasses: string = splitValues[1]
+          // NOTE: This prop assignment does *not* enforce typing...
+          matchingLines = {...matchingLines, [elementType]: addtClasses}
+        // NOTE: not able to reach this else statement currently?
+        } else {
+          throw new Error(`Invalid syntax for MyST panel styling`)
+        }
+      }
+    }
+  }
+  return matchingLines
+}
+
+export function parseCardStyling() {
+
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -31,7 +31,7 @@ export function parsePanel(contents: string): MystPanel {
     const parsedCard = { body: body } as MystCard;
     parsedCard.style = defaultCardStyle;
     if (panelStyle) {
-      parsedCard.style = mergeStyles(panelStyle, defaultCardStyle);
+      parsedCard.style = mergeStyles(defaultCardStyle, panelStyle);
     }
     // card style merges with panel style
     if (bodyYaml.length !== 0) {
@@ -84,7 +84,7 @@ export function parseStyling(contents: string): [string, string] {
     yamlBlock = yamlLines.join("\n");
   }
 
-  returnContents = contentLines.join("\n");
+  returnContents = contentLines.join("\n").trim();
   const returnPanel: [string, string] = [yamlBlock, returnContents];
   return returnPanel;
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -84,7 +84,3 @@ export function parsePanelStyling(contents: string) {
   const returnPanel: [MystPanelStyling, string] = [styles, panelContents]
   return returnPanel
 }
-
-export function parseCardStyling() {
-
-}

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -36,7 +36,7 @@ export function parsePanel(contents: string): MystPanel {
     // card style merges with panel style
     if (bodyYaml.length !== 0) {
       const cardStyle = parseYamlBlock(bodyYaml);
-      parsedCard.style = mergeStyles(parsedCard.style!, cardStyle);
+      parsedCard.style = mergeStyles(parsedCard.style, cardStyle);
     }
     if (headerDelimiterRegex.test(body)) {
       const contents = body.split(headerDelimiterRegex);

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -1,5 +1,3 @@
-import type { YieldExpression } from "@babel/types";
-import e from "express";
 import type { MystCard, MystPanel } from "./types";
 
 export function parsePanel(contents: string): MystPanel {
@@ -17,7 +15,9 @@ export function parsePanel(contents: string): MystPanel {
   // retrieve header and footer for each card if exists
   for (const card of cards) {
     let header, footer;
-    let [bodyYaml, body] = parseStyling(card);
+    const cardComponents = parseStyling(card);
+    const bodyYaml = cardComponents[0];
+    let body = cardComponents[1]
     const parsedCard = { body: body } as MystCard;
     if (bodyYaml.length !== 0) {
       //parsedCard.style = parseYamlBlock(bodyYaml)
@@ -51,17 +51,17 @@ export function parsePanel(contents: string): MystPanel {
   return myPanel
 }
 
-export function parseStyling(contents: string) {
+export function parseStyling(contents: string): [string, string] {
   let yamlBlock = '';
   let returnContents = '';
-  let contentLines = contents.split("\n") 
+  const contentLines = contents.split("\n") 
   if (contents.startsWith(":")) {
-    let yamlLines: Array<string> = []
+    const yamlLines: Array<string> = []
     while (contentLines) {
       if (!ltrim(contentLines[0]).startsWith(":")) {
         break
       } else {
-        yamlLines.push(ltrim(contentLines.shift()!))
+        yamlLines.push(ltrim(contentLines.shift()!)) // TODO: Find way to fix non-null assertion warning
       }
     }
     yamlBlock = yamlLines.join("\n")
@@ -72,8 +72,8 @@ export function parseStyling(contents: string) {
   return returnPanel
 }
 
-export function parseYamlBlock(yamlBlock: string) {
-  let styleContents = yamlBlock.split("\n")
+export function parseYamlBlock(yamlBlock: string) : Record<string, unknown> {
+  const styleContents = yamlBlock.split("\n")
   const stylingRegex = /^:([a-z0-9]+):\s*([a-z\s\-0-9]+)/i;
   // return object with key value pairs
   let styles = {}

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -7,7 +7,10 @@ export function parsePanel(contents: string): MystPanel {
 
   // get panel styling from beginning of panel if it exists
   const [yamlBlock, panelContents] = parseStyling(contents);
-  const panelStyle = parseYamlBlock(yamlBlock);
+  let panelStyle;
+  if (yamlBlock.length !== 0) {
+    panelStyle = parseYamlBlock(yamlBlock);
+  }
   // first retrieve cards
   const cards = panelContents.split(panelDelimiterRegex);
   const splitCards: Array<MystCard> = [];
@@ -50,7 +53,7 @@ export function parsePanel(contents: string): MystPanel {
   }
 
   let myPanel: MystPanel = {cards: splitCards}
-  if (yamlBlock.length !== 0) {
+  if (panelStyle) {
     myPanel = {...myPanel, style: panelStyle}
   }
   return myPanel

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -12,28 +12,31 @@ export function parsePanel(contents: string): MystPanel {
     panelStyle = parseYamlBlock(yamlBlock);
   }
   // first retrieve cards
-  const cards = panelContents.split(panelDelimiterRegex);
+  const cards = panelContents.startsWith("---\n")
+    ? panelContents.substring(4).split(panelDelimiterRegex)
+    : panelContents.split(panelDelimiterRegex);
   const splitCards: Array<MystCard> = [];
 
-  const defaultCardStyle = {column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2",
-                            card: "w-100",
-                            } as MystStyling
+  const defaultCardStyle = {
+    column: "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2",
+    card: "w-100",
+  } as MystStyling;
 
   // retrieve header and footer for each card if exists
   for (const card of cards) {
     let header, footer;
     const cardComponents = parseStyling(card);
     const bodyYaml = cardComponents[0];
-    let body = cardComponents[1]
+    let body = cardComponents[1];
     const parsedCard = { body: body } as MystCard;
     parsedCard.style = defaultCardStyle;
     if (panelStyle) {
-      parsedCard.style = mergeStyles(panelStyle, defaultCardStyle)
+      parsedCard.style = mergeStyles(panelStyle, defaultCardStyle);
     }
     // card style merges with panel style
     if (bodyYaml.length !== 0) {
-      const cardStyle = parseYamlBlock(bodyYaml)
-      parsedCard.style = mergeStyles(parsedCard.style!, cardStyle)
+      const cardStyle = parseYamlBlock(bodyYaml);
+      parsedCard.style = mergeStyles(parsedCard.style!, cardStyle);
     }
     if (headerDelimiterRegex.test(body)) {
       const contents = body.split(headerDelimiterRegex);
@@ -57,101 +60,105 @@ export function parsePanel(contents: string): MystPanel {
     splitCards.push(parsedCard);
   }
 
-  let myPanel: MystPanel = {cards: splitCards}
+  let myPanel: MystPanel = { cards: splitCards };
   if (panelStyle) {
-    myPanel = {...myPanel, style: panelStyle}
+    myPanel = { ...myPanel, style: panelStyle };
   }
-  return myPanel
+  return myPanel;
 }
 
 export function parseStyling(contents: string): [string, string] {
-  let yamlBlock = '';
-  let returnContents = '';
-  const contentLines = contents.split("\n") 
+  let yamlBlock = "";
+  let returnContents = "";
+  const contentLines = contents.split("\n");
   if (contents.startsWith(":")) {
-    const yamlLines: Array<string> = []
+    const yamlLines: Array<string> = [];
     while (contentLines) {
       if (!ltrim(contentLines[0]).startsWith(":")) {
-        break
+        break;
       } else {
         // TODO: Find way to fix non-null assertion warning
-        yamlLines.push(ltrim(contentLines.shift()!)) 
+        yamlLines.push(ltrim(contentLines.shift()!));
       }
     }
-    yamlBlock = yamlLines.join("\n")
+    yamlBlock = yamlLines.join("\n");
   }
 
-  returnContents = contentLines.join("\n")  
-  const returnPanel: [string, string] = [yamlBlock, returnContents]
-  return returnPanel
+  returnContents = contentLines.join("\n");
+  const returnPanel: [string, string] = [yamlBlock, returnContents];
+  return returnPanel;
 }
 
-export function parseYamlBlock(yamlBlock: string) : Record<string, unknown> {
-  const styleContents = yamlBlock.split("\n")
+export function parseYamlBlock(yamlBlock: string): Record<string, unknown> {
+  const styleContents = yamlBlock.split("\n");
   const stylingRegex = /^:([a-z0-9]+):\s*([a-z\s\-0-9]+)/i;
   // return object with key value pairs
-  let styles = {}
+  let styles = {};
   for (const line of styleContents) {
-    const stylingArray : RegExpExecArray | null = stylingRegex.exec(line)
+    const stylingArray: RegExpExecArray | null = stylingRegex.exec(line);
     if (stylingArray && stylingArray.length > 2) {
-      const key : string = stylingArray[1]
-      const value : string = stylingArray[2]
-      styles = {...styles, [key]: value}
+      const key: string = stylingArray[1];
+      const value: string = stylingArray[2];
+      styles = { ...styles, [key]: value };
     }
   }
-  return styles
+  return styles;
 }
 
 function ltrim(rawString: string) {
-  return rawString.replace(/^\s+/gm,'');
+  return rawString.replace(/^\s+/gm, "");
 }
 
-export function mergeStyles(panelStyle: MystStyling, cardStyle: MystStyling) : MystStyling {
+export function mergeStyles(
+  panelStyle: MystStyling,
+  cardStyle: MystStyling
+): MystStyling {
   let k: keyof MystStyling;
   for (k in panelStyle) {
     if (k in cardStyle) {
-      const panelPropDict = classesStringToKeyValues(panelStyle[k]!)
-      const cardPropDict = classesStringToKeyValues(cardStyle[k]!)
+      const panelPropDict = classesStringToKeyValues(panelStyle[k]!);
+      const cardPropDict = classesStringToKeyValues(cardStyle[k]!);
       // merge Dicts
-      const mergedProps = {...panelPropDict, ...cardPropDict}
-      cardStyle[k] = propDictToString(mergedProps)
+      const mergedProps = { ...panelPropDict, ...cardPropDict };
+      cardStyle[k] = propDictToString(mergedProps);
     } else {
-      cardStyle[k] = panelStyle[k]
+      cardStyle[k] = panelStyle[k];
     }
   }
-  return cardStyle
+  return cardStyle;
 }
 
-export function classesStringToKeyValues(classesString: string) : Record<string, string> {
-  const htmlClasses = classesString.split(/\s+/)
-  let classDictionary = {}
+export function classesStringToKeyValues(
+  classesString: string
+): Record<string, string> {
+  const htmlClasses = classesString.split(/\s+/);
+  let classDictionary = {};
   for (const htmlClass of htmlClasses) {
-    const classArray = htmlClass.split('-')
-    let key, value
+    const classArray = htmlClass.split("-");
+    let key, value;
     // deal with single prop like "shadow"
     if (classArray.length === 1) {
-      key = classArray[0]
-      value = '';
-    } 
-    else {
-      value = classArray.pop()
-      key = classArray.join('-')
+      key = classArray[0];
+      value = "";
+    } else {
+      value = classArray.pop();
+      key = classArray.join("-");
     }
-    classDictionary = {...classDictionary, [key]: value}
+    classDictionary = { ...classDictionary, [key]: value };
   }
-  return classDictionary
+  return classDictionary;
 }
 
-function propDictToString(classObject: Record<string, string>) : string {
-  let returnString = ''
+function propDictToString(classObject: Record<string, string>): string {
+  let returnString = "";
   for (const key in classObject) {
     let concatValue;
-    if (classObject[key] === '') {
-      concatValue = key
+    if (classObject[key] === "") {
+      concatValue = key;
     } else {
-      concatValue = [key, classObject[key]].join("-")
+      concatValue = [key, classObject[key]].join("-");
     }
     returnString = returnString + " " + concatValue;
   }
-  return ltrim(returnString)
+  return ltrim(returnString);
 }

--- a/packages/compiler/src/myst.ts
+++ b/packages/compiler/src/myst.ts
@@ -8,9 +8,9 @@ export function parsePanel(contents: string): Array<MystCard> {
   const footerDelimiterRegex = /\n\+{3,}\n/;
 
   // get panel styling from beginning of panel if it exists
-  const panelStyles = parsePanelStyling(contents);
+  const [panelStyling, panelContents] = parsePanelStyling(contents);
   // first retrieve cards
-  const cards = contents.split(panelDelimiterRegex);
+  const cards = panelContents.split(panelDelimiterRegex);
   const splitCards = [];
 
   // retrieve header and footer for each card if exists
@@ -47,11 +47,13 @@ export function parsePanelStyling(contents: string) {
   // TO ASK: This regex was a PITA. 
   // Is there a way to get it to do this without having to split contents by newline?
   const panelStylingRegex = /:[a-z]+:\s[a-z\s\-0-9]+/i;
+  let panelContentLine;
   let matchingLines: MystPanelStyling = ({} as any) as MystPanelStyling;
   // panel styling is only at the beginning of the panels
   for (let i = 0; i < contentLines.length; i++) {
     // stop processing lines once individual cards declared
     if (!contentLines[i].startsWith(":")) {
+      panelContentLine = i
       break
     } else {
       const valueMatch = contentLines[i].match(panelStylingRegex)
@@ -69,7 +71,12 @@ export function parsePanelStyling(contents: string) {
       }
     }
   }
-  return matchingLines
+
+  // reconstitute panelContent
+  const panelContents = contentLines.slice(panelContentLine).join("\n")  
+  console.log(typeof (panelContents))
+  const returnPanel: [MystPanelStyling, string] = [matchingLines, panelContents]
+  return returnPanel
 }
 
 export function parseCardStyling() {

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -82,11 +82,18 @@ export const processMyst = () => {
         } else if (mystType === "panels") {
           const panel = parsePanel(value);
           const htmlCards = panel.cards.map((card: MystCard) => {
+            //console.log(card.style)
             let k: keyof MystCard;
+            let micromarkCard = {} as MystCard;
             for (k in card) {
-              card[k] = micromark(card[k]);
+              if (k !== "style") {
+                micromarkCard[k] = micromark(card[k]);
+              }
             }
-            return card;
+            if (card.style) {
+              micromarkCard = {...micromarkCard, style: card.style}
+            }
+            return micromarkCard;
           });
           // parse each card
           const newNode = {
@@ -94,11 +101,11 @@ export const processMyst = () => {
             value: mustache.render(
               `<Panels panelStyle="{{{styles.container}}}">
                {{#cards}}
-               <Card columnStyle="{{{styles.column}}}"
-                     cardStyle="{{{styles.card}}}"
-                     headerStyle="{{{styles.header}}}"
-                     bodyStyle="{{{styles.body}}}"
-                     footerStyle="{{{styles.footer}}}"
+               <Card columnStyle="{{{style.column}}}"
+                     cardStyle="{{{style.card}}}"
+                     headerStyle="{{{style.header}}}}"
+                     bodyStyle="{{{style.body}}}"
+                     footerStyle="{{{style.footer}}}"
                      >
                {{#header}}
                <div slot="header">

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -83,14 +83,14 @@ export const processMyst = () => {
           const panel = parsePanel(value);
           const htmlCards = panel.cards.map((card: MystCard) => {
             let k: keyof MystCard;
-            let micromarkCard = {} as MystCard;
+            let micromarkCard = {} as Record<string, string>;
             for (k in card) {
               if (k !== "style") {
                 micromarkCard[k] = micromark(card[k]);
               }
             }
             if (card.style) {
-              micromarkCard = {...micromarkCard, style: card.style}
+              micromarkCard = {...micromarkCard, style: "{" + JSON.stringify(card.style) + "}"}
             }
             return micromarkCard;
           });
@@ -98,14 +98,9 @@ export const processMyst = () => {
           const newNode = {
             type: "html",
             value: mustache.render(
-              `<Panels panelStyle="{{{styles.container}}}">
+              `<Panels style="{{{styles.container}}}">
                {{#cards}}
-               <Card columnStyle="{{{style.column}}}"
-                     cardStyle="{{{style.card}}}"
-                     headerStyle="{{{style.header}}}"
-                     bodyStyle="{{{style.body}}}"
-                     footerStyle="{{{style.footer}}}"
-                     >
+               <Card style={{{style}}}>
                {{#header}}
                <div slot="header">
                {{{header}}}

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -80,8 +80,8 @@ export const processMyst = () => {
           (parent as Parent).children[index] = newNode;
           return index;
         } else if (mystType === "panels") {
-          const mdCards = parsePanel(value);
-          const htmlCards = mdCards.map((card: MystCard) => {
+          const panel = parsePanel(value);
+          const htmlCards = panel.cards.map((card: MystCard) => {
             let k: keyof MystCard;
             for (k in card) {
               card[k] = micromark(card[k]);
@@ -89,14 +89,14 @@ export const processMyst = () => {
             return card;
           });
           // create dummy object to access array properties with mustache
-          const cards = { cards: htmlCards };
+          const cards = { cards: htmlCards, styles: panel.style };
           // parse each card
           const newNode = {
             type: "html",
             value: mustache.render(
               `<Panels>
                {{#cards}}
-               <Card>
+               <Card class="{{#class}}{{styles.card}}{{/class}}">
                {{#header}}
                <div slot="header">
                {{{header}}}

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -82,7 +82,6 @@ export const processMyst = () => {
         } else if (mystType === "panels") {
           const panel = parsePanel(value);
           const htmlCards = panel.cards.map((card: MystCard) => {
-            //console.log(card.style)
             let k: keyof MystCard;
             let micromarkCard = {} as MystCard;
             for (k in card) {

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -88,15 +88,17 @@ export const processMyst = () => {
             }
             return card;
           });
-          // create dummy object to access array properties with mustache
-          const cards = { cards: htmlCards, styles: panel.style };
           // parse each card
           const newNode = {
             type: "html",
             value: mustache.render(
-              `<Panels>
+              `<Panels panelStyle=\"{{{styles.container}}}\">
                {{#cards}}
-               <Card class="{{#class}}{{styles.card}}{{/class}}">
+               <Card cardStyle=\"{{{styles.column}}}\"
+                     headerStyle=\"{{{styles.header}}}\"
+                     bodyStyle=\"{{{styles.body}}}\"
+                     footerStyle=\"{{{styles.footer}}}\"
+                     >
                {{#header}}
                <div slot="header">
                {{{header}}}
@@ -113,7 +115,7 @@ export const processMyst = () => {
                </Card>
                {{/cards}}
                </Panels>`,
-              cards
+              {cards: htmlCards, styles: panel.style}
             ),
           };
           (parent as Parent).children[index] = newNode;

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -103,7 +103,7 @@ export const processMyst = () => {
                {{#cards}}
                <Card columnStyle="{{{style.column}}}"
                      cardStyle="{{{style.card}}}"
-                     headerStyle="{{{style.header}}}}"
+                     headerStyle="{{{style.header}}}"
                      bodyStyle="{{{style.body}}}"
                      footerStyle="{{{style.footer}}}"
                      >

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -92,12 +92,13 @@ export const processMyst = () => {
           const newNode = {
             type: "html",
             value: mustache.render(
-              `<Panels panelStyle=\"{{{styles.container}}}\">
+              `<Panels panelStyle="{{{styles.container}}}">
                {{#cards}}
-               <Card cardStyle=\"{{{styles.column}}}\"
-                     headerStyle=\"{{{styles.header}}}\"
-                     bodyStyle=\"{{{styles.body}}}\"
-                     footerStyle=\"{{{styles.footer}}}\"
+               <Card columnStyle="{{{styles.column}}}"
+                     cardStyle="{{{styles.card}}}"
+                     headerStyle="{{{styles.header}}}"
+                     bodyStyle="{{{styles.body}}}"
+                     footerStyle="{{{styles.footer}}}"
                      >
                {{#header}}
                <div slot="header">

--- a/packages/compiler/src/svelteToHTML.ts
+++ b/packages/compiler/src/svelteToHTML.ts
@@ -134,6 +134,7 @@ export async function svelteToHTML(
     ...svelteComponents,
   ]);
   const svelteJs = await createSvelteBundle(files);
+  console.log(mdSvelte);
   return {
     html: mustache.render(bundleIndexSource, {
       ...options,

--- a/packages/compiler/src/svelteToHTML.ts
+++ b/packages/compiler/src/svelteToHTML.ts
@@ -134,7 +134,6 @@ export async function svelteToHTML(
     ...svelteComponents,
   ]);
   const svelteJs = await createSvelteBundle(files);
-  console.log(mdSvelte);
   return {
     html: mustache.render(bundleIndexSource, {
       ...options,

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -8,17 +8,17 @@
 </script>
 
 <div class={columnStyle}>
-  <div class={cardStyle}>
+  <div class={"card " + cardStyle}>
     {#if $$slots.header}
-      <div class={headerStyle}>
+      <div class={"card-header " + headerStyle}>
         <slot name="header" />
       </div>
     {/if}
-    <div class={bodyStyle}>
+    <div class={"card-body " + bodyStyle}>
       <slot name="body" />
     </div>
     {#if $$slots.footer}
-      <div class={footerStyle}>
+      <div class={"card-footer " + footerStyle}>
         <slot name="footer" />
       </div>
     {/if}

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,13 +1,13 @@
 <script>
-  export let cardStyle = ''; // blank string as default
+  export let columnStyle = ''; // blank string as default
   export let headerStyle = ''
   export let bodyStyle = ''
   export let footerStyle = ''
-  let fullStyle = "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2 " + cardStyle
+  export let cardStyle = ''
 </script>
 
-<div class={fullStyle}>
-  <div class="card w-100">
+<div class={"d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2 " + columnStyle}>
+  <div class={"card w-100 " + cardStyle}>
     {#if $$slots.header}
       <div class={"card-header " + headerStyle}>
         <slot name="header" />

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,25 +1,24 @@
 <script>
   // Note: These have to be explicit props as mustache.render cannot pass an object to Svelte
   export let columnStyle = ''; // blank string as default
-  export let headerStyle = ''
-  export let bodyStyle = ''
-  export let footerStyle = ''
-  export let cardStyle = ''
+  export let headerStyle = '';
+  export let bodyStyle = '';
+  export let footerStyle = '';
+  export let cardStyle = '';
 </script>
 
-<div class={"d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2 " + columnStyle}>
-  <div class={"card w-100 " + cardStyle}>
+<div class={columnStyle}>
+  <div class={cardStyle}>
     {#if $$slots.header}
-      <div class={"card-header " + headerStyle}>
+      <div class={headerStyle}>
         <slot name="header" />
       </div>
     {/if}
-    <div class={"card-body " + bodyStyle}>
+    <div class={bodyStyle}>
       <slot name="body" />
     </div>
-
     {#if $$slots.footer}
-      <div class={"card-footer " + footerStyle}>
+      <div class={footerStyle}>
         <slot name="footer" />
       </div>
     {/if}

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,4 +1,5 @@
 <script>
+  // Note: These have to be explicit props as mustache.render cannot pass an object to Svelte
   export let columnStyle = ''; // blank string as default
   export let headerStyle = ''
   export let bodyStyle = ''

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,24 +1,20 @@
 <script>
-  // Note: These have to be explicit props as mustache.render cannot pass an object to Svelte
-  export let columnStyle = ''; // blank string as default
-  export let headerStyle = '';
-  export let bodyStyle = '';
-  export let footerStyle = '';
-  export let cardStyle = '';
+  export let style = {};
+  
 </script>
 
-<div class={columnStyle}>
-  <div class={"card " + cardStyle}>
+<div class={style.column}>
+  <div class={"card " + style.card}>
     {#if $$slots.header}
-      <div class={"card-header " + headerStyle}>
+      <div class={"card-header " + style.header}>
         <slot name="header" />
       </div>
     {/if}
-    <div class={"card-body " + bodyStyle}>
+    <div class={"card-body " + style.body}>
       <slot name="body" />
     </div>
     {#if $$slots.footer}
-      <div class={"card-footer " + footerStyle}>
+      <div class={"card-footer " + style.footer}>
         <slot name="footer" />
       </div>
     {/if}

--- a/packages/compiler/src/templates/Card.svelte
+++ b/packages/compiler/src/templates/Card.svelte
@@ -1,16 +1,24 @@
-<div class="d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2">
+<script>
+  export let cardStyle = ''; // blank string as default
+  export let headerStyle = ''
+  export let bodyStyle = ''
+  export let footerStyle = ''
+  let fullStyle = "d-flex col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2 " + cardStyle
+</script>
+
+<div class={fullStyle}>
   <div class="card w-100">
     {#if $$slots.header}
-      <div class="card-header">
+      <div class={"card-header " + headerStyle}>
         <slot name="header" />
       </div>
     {/if}
-    <div class="card-body">
+    <div class={"card-body " + bodyStyle}>
       <slot name="body" />
     </div>
 
     {#if $$slots.footer}
-      <div class="card-footer">
+      <div class={"card-footer " + footerStyle}>
         <slot name="footer" />
       </div>
     {/if}

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,4 +1,9 @@
-<div class="container">
+<script>
+  export let panelStyle = ''; // blank string as default
+  let fullStyle = "container " + panelStyle
+</script>
+
+<div class={fullStyle}>
   <div class="row">
     <slot />
   </div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,8 +1,8 @@
 <script>
-  export let panelStyle = ''; // blank string as default
+  export let style = ''; // blank string as default
 </script>
 
-<div class={"container " + panelStyle}>
+<div class={"container " + style}>
   <div class="row">
     <slot />
   </div>

--- a/packages/compiler/src/templates/Panels.svelte
+++ b/packages/compiler/src/templates/Panels.svelte
@@ -1,9 +1,8 @@
 <script>
   export let panelStyle = ''; // blank string as default
-  let fullStyle = "container " + panelStyle
 </script>
 
-<div class={fullStyle}>
+<div class={"container " + panelStyle}>
   <div class="row">
     <slot />
   </div>

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -45,6 +45,7 @@ export interface ParsedDocument {
 }
 
 export interface MystCard {
+  style?: MystStyling;
   header?: string;
   body: string;
   footer?: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -50,6 +50,22 @@ export interface MystCard {
   footer?: string;
 }
 
+export interface MystPanelStyling {
+  container?: string,
+  column?: string,
+  card?: string,
+  body?: string,
+  header?: string,
+  footer?: string
+}
+
+export interface MystCardStyling {
+  column?: string,
+  body?: string,
+  header?: string,
+  footer?: string
+}
+
 export interface SvelteComponentDefinition {
   code: string;
   map: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -45,14 +45,21 @@ export interface ParsedDocument {
 }
 
 export interface MystCard {
-  style?: string;
   header?: string;
   body: string;
   footer?: string;
 }
 
+export interface MystStyling {
+  container?: string;
+  header?: string;
+  body?: string;
+  footer?: string;
+  column?: string;
+}
+
 export interface MystPanel {
-  style?: string;
+  style?: MystStyling;
   cards: Array<MystCard>;
 }
 

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -50,6 +50,11 @@ export interface MystCard {
   footer?: string;
 }
 
+export interface MystPanel {
+  style?: MystPanelStyling;
+  cards: Array<MystCard>;
+}
+
 export interface MystPanelStyling {
   container?: string,
   column?: string,

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -45,30 +45,15 @@ export interface ParsedDocument {
 }
 
 export interface MystCard {
+  style?: string;
   header?: string;
   body: string;
   footer?: string;
 }
 
 export interface MystPanel {
-  style?: MystPanelStyling;
+  style?: string;
   cards: Array<MystCard>;
-}
-
-export interface MystPanelStyling {
-  container?: string,
-  column?: string,
-  card?: string,
-  body?: string,
-  header?: string,
-  footer?: string
-}
-
-export interface MystCardStyling {
-  column?: string,
-  body?: string,
-  header?: string,
-  footer?: string
 }
 
 export interface SvelteComponentDefinition {

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -61,10 +61,6 @@ This is a body styled based on card styling.
 This is a body styled based on panel styling.
 ```
 
-
-
-
-
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123
 [panels]: https://jupyterbook.org/content/content-blocks.html#panels

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -31,6 +31,41 @@ This is a panel with only a body and footer.
 Footer
 ```
 
+Panel contents can also styled using Bootstrap [styles]. Styles can be applied for all cards or on a per card basis.
+
+```{panels}
+:body: text-center
+:header: bg-warning
+This is a header styled based on panel styling.
+^^^
+This is a body styled based on panel styling.
++++
+This is a footer
+---
+:column: col-lg-4 col-md-4 col-sm-4 col-xs-6 
+:card: shadow
+:header: bg-info p-4
+:body: text-justify
+:footer: text-center
+This is a header styled based on panel styling.
+^^^
+This is a card and body styled based on card styling.
++++
+This is a footer styled per card.
+---
+:body: text-danger
+This is a header styled based on panel styling.
+^^^
+This is a body styled based on card styling.
+---
+This is a body styled based on panel styling.
+```
+
+
+
+
+
 [myst markdown format]: https://myst-parser.readthedocs.io/en/latest/index.html
 [irydium/irydium#123]: https://github.com/irydium/irydium/issues/123
 [panels]: https://jupyterbook.org/content/content-blocks.html#panels
+[styles]: https://getbootstrap.com/docs/5.1/components/card/

--- a/packages/site/static/examples/myst-support.md
+++ b/packages/site/static/examples/myst-support.md
@@ -47,11 +47,11 @@ This is a footer
 :header: bg-info p-4
 :body: text-justify
 :footer: text-center
-This is a header styled based on panel styling.
+This is a header styled based on card styling.
 ^^^
 This is a card and body styled based on card styling.
 +++
-This is a footer styled per card.
+This is a footer styled based on card styling.
 ---
 :body: text-danger
 This is a header styled based on panel styling.


### PR DESCRIPTION
Based on [JupyterBook](https://jupyterbook.org/content/content-blocks.html#panels).

- Add support for styling cards (background colors, text colors, padding, borders, etc.) according to [Bootstrap](https://getbootstrap.com/docs/5.0/components/card/#card-styles)