### PR TITLE
Preliminary sessionStorage based cache

### DIFF
--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -6,13 +6,13 @@ import { Node, Parent, visit } from "unist-util-visit";
 import { parse as svelteParse } from "svelte/compiler";
 
 import { parsePanel } from "./myst";
+import { stringHash } from "./stringHash";
 import { taskScriptSource } from "./templates";
 import type {
   CodeNode,
   CodeNodeAttributes,
   ParsedDocument,
   ScriptNode,
-  MystCard,
 } from "./types";
 import type { Code, HTML, Text } from "mdast";
 
@@ -375,7 +375,7 @@ export const augmentSvx = ({
             .filter(
               (taskVariable) => !Object.keys(frontMatter).includes(taskVariable)
             ),
-          tasks,
+          tasks: tasks.map(task => ({...task, hash: stringHash(task.payload)})),
         });
 
       visit(tree, "root", (node: Parent) => {

--- a/packages/compiler/src/stringHash.ts
+++ b/packages/compiler/src/stringHash.ts
@@ -1,0 +1,14 @@
+// taken from: https://github.com/darkskyapp/string-hash
+export function stringHash(str: string): number {
+  let hash = 5381,
+    i = str.length;
+
+  while (i) {
+    hash = (hash * 33) ^ str.charCodeAt(--i);
+  }
+
+  /* JavaScript does bitwise operations (like XOR, above) on 32-bit signed
+   * integers. Since we want the results to be always positive, convert the
+   * signed int to an unsigned by doing an unsigned bitshift. */
+  return hash >>> 0;
+}

--- a/packages/compiler/src/taskrunner.js
+++ b/packages/compiler/src/taskrunner.js
@@ -1,4 +1,4 @@
-/* global _ */
+/* global _, globalThis */
 
 export const TASK_TYPE = {
   LOAD_SCRIPTS: 0,
@@ -60,10 +60,10 @@ function getCachedData(task) {
   const cacheKey = getCacheKey(task);
   if (
     cacheKey !== undefined &&
-    window.sessionStorage &&
+    globalThis.sessionStorage !== undefined &&
     window.sessionStorage.getItem(cacheKey)
   ) {
-    return JSON.parse(window.sessionStorage.getItem(cacheKey));
+    return JSON.parse(sessionStorage.getItem(cacheKey));
   }
   return undefined;
 }
@@ -72,12 +72,12 @@ function setCachedData(task, value) {
   const cacheKey = getCacheKey(task);
   if (
     cacheKey !== undefined &&
-    window.sessionStorage &&
+    globalThis.sessionStorage &&
     isSerializable(value)
   ) {
     const stringified = JSON.stringify(value);
     if (stringified.length <= MAX_SERIALIZABLE_LENGTH) {
-      window.sessionStorage.setItem(cacheKey, stringified);
+      sessionStorage.setItem(cacheKey, stringified);
     }
   }
 }

--- a/packages/compiler/src/templates/index.html
+++ b/packages/compiler/src/templates/index.html
@@ -35,6 +35,7 @@
         border: 0;
       }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <script id="svelteapp" type="text/plain">
       {{{ svelteJs }}}
     </script>

--- a/packages/compiler/src/templates/tasks.js
+++ b/packages/compiler/src/templates/tasks.js
@@ -16,6 +16,9 @@ const __tasks = [
     type: {{type}},
     payload: {{{payload}}},
     state: {{state}},
+    {{#hash}}
+    hash: {{{hash}}},
+    {{/hash}}
     inputs: {{{inputs}}}
   },
   {{/tasks}}

--- a/packages/site/src/components/Output.svelte
+++ b/packages/site/src/components/Output.svelte
@@ -6,7 +6,7 @@
   export let title = "Untitled Document";
   let srcdoc = "Loading...";
 
-  const updateDoc = throttle(async (md) => {
+  const updateDoc = throttle(async (md: string) => {
     try {
       const output = await compile(md);
       srcdoc = output.html;


### PR DESCRIPTION
Introduce a cache based on sessionStorage for local workflows. This
only caches a very small amount of data (100k or less), only works
for JSON serializable data, and only works inside a single session. However, it's still
a user-visible improvement over what was there previously.

Partially fixes #217.
