### PR TITLE
Improve dependency resolution

### DIFF
--- a/.changeset/sour-experts-relate.md
+++ b/.changeset/sour-experts-relate.md
@@ -1,0 +1,5 @@
+---
+"@irydium/compiler": patch
+---
+
+Improve dependency resolution


### PR DESCRIPTION
Borrowing approaches used by the svelte repl.

In particular, we now handle `./foo` imports better (mainly by
switching our CDN from jsdelivr to unpkg), which allows us to import
and use graph-paper.

Also, cache dependencies in-memory after downloading (helps improve repl performance).