### PR TITLE
Prefix the URL with http when logging

### DIFF
--- a/.changeset/tasty-dancers-double.md
+++ b/.changeset/tasty-dancers-double.md
@@ -1,0 +1,5 @@
+---
+"@irydium/viewer": patch
+---
+
+Prefix the URL with http when logging

--- a/packages/viewer/src/cli.js
+++ b/packages/viewer/src/cli.js
@@ -100,5 +100,5 @@ polka()
   })
   .listen(3000, (err) => {
     if (err) throw err;
-    console.log(`> Running on localhost:3000`);
+    console.log(`> Running on http://localhost:3000`);
   });


### PR DESCRIPTION
My terminal makes a http-prefix cmd-clickable to open it in a browser.
That doesn't work for just `localhost:3000`.