### PR TITLE
Set default charset in irydium HTML

### DIFF
--- a/.changeset/modern-drinks-sniff.md
+++ b/.changeset/modern-drinks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@irydium/compiler": patch
+---
+
+Set default charset in irydium HTML

--- a/packages/compiler/src/templates/index.html
+++ b/packages/compiler/src/templates/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title>{{ title }}</title>
     <base target="_blank" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU" crossorigin="anonymous"/>


### PR DESCRIPTION
This is important when the character set isn't specified by the
server (e.g. when serving irydium content with `python -mhttp.server`).
