### PR TITLE
Basic syntax checking of js code chunks

### DIFF
--- a/.changeset/light-timers-complain.md
+++ b/.changeset/light-timers-complain.md
@@ -1,0 +1,5 @@
+---
+"@irydium/compiler": patch
+---
+
+Basic syntax checking of js code chunks

--- a/packages/compiler/__tests__/parseMd.tests.js
+++ b/packages/compiler/__tests__/parseMd.tests.js
@@ -27,6 +27,33 @@ describe("extractCode basics", () => {
     });
   });
 
+  it("should allow top-level await", async () => {
+    expect(
+      await extractCode(
+        createCodeCell(
+          "js",
+          "base",
+          undefined,
+          "return await fetch('http://google.com')"
+        )
+      )
+    ).toEqual({
+      frontMatter: {},
+      scripts: [],
+      codeCells: [
+        {
+          attributes: {
+            id: "base",
+          },
+          body: "return await fetch('http://google.com')",
+          bodyBegin: 4,
+          frontmatter: "id: base",
+          lang: "js",
+        },
+      ],
+    });
+  });
+
   it("should handle a syntax error as expected", async () => {
     await expect(async () => {
       await extractCode(createCodeCell("js", "base", undefined, "!x = 5"));

--- a/packages/compiler/__tests__/parseMd.tests.js
+++ b/packages/compiler/__tests__/parseMd.tests.js
@@ -26,6 +26,14 @@ describe("extractCode basics", () => {
       ],
     });
   });
+
+  it("should handle a syntax error as expected", async () => {
+    await expect(async () => {
+      await extractCode(createCodeCell("js", "base", undefined, "!x = 5"));
+    }).rejects.toThrow(
+      new Error("Syntax error in js cell: Assigning to rvalue (line: 5)")
+    );
+  });
 });
 
 describe("extractCode imports", () => {

--- a/packages/compiler/src/parseMd.ts
+++ b/packages/compiler/src/parseMd.ts
@@ -101,7 +101,7 @@ export async function extractCode(
         // we pre-process js cells to make sure the syntax is valid
         if (lang === "js") {
           try {
-            acornParser.parse(nodeContent.body, {ecmaVersion: 2021, allowReturnOutsideFunction: true});
+            acornParser.parse(nodeContent.body, {ecmaVersion: 2021, allowReturnOutsideFunction: true, allowAwaitOutsideFunction: true});
           } catch (e) {
             if (e instanceof SyntaxError) {
               // Renumber syntax error, since the code we're parsing is part of a much larger document

--- a/packages/compiler/src/parseMd.ts
+++ b/packages/compiler/src/parseMd.ts
@@ -105,8 +105,11 @@ export async function extractCode(
           } catch (e) {
             if (e instanceof SyntaxError) {
               // Renumber syntax error, since the code we're parsing is part of a much larger document
-              const revisedMessage = e.message.replace(/\ \([0-9]+:[0-9]+\)$/, '') + ` (line: ${node.position.start.line + nodeContent.bodyBegin + e.loc.line - 1})`;
-              throw new Error(`Syntax error in js cell: ${revisedMessage}`);
+              const line = parseInt(e.loc.line); // @ts-ignore
+              const actualLine = node.position ? (node.position.start.line + nodeContent.bodyBegin + line - 1) : "unknown";
+              const revisedMessage = e.message.replace(/ \(\d+:\d+\)$/, '') + ` (line: ${actualLine})`;
+              throw new Error(`Syntax error in js cell: ${revisedMessage}`);n
+
             }
             // unknown error, shouldn't happen, just rethrow I guess
             throw e;

--- a/packages/compiler/src/parseMd.ts
+++ b/packages/compiler/src/parseMd.ts
@@ -105,7 +105,12 @@ export async function extractCode(
           } catch (e) {
             if (e instanceof SyntaxError) {
               // Renumber syntax error, since the code we're parsing is part of a much larger document
-              const line = parseInt(e.loc.line); // @ts-ignore
+
+              // Acorn overrides the SyntaxError class, but TS/Eslint doesn't know about the `loc` property.
+              // Let's just assume it exists.
+              // @ts-ignore
+              const line = parseInt(e.loc.line); // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+
               const actualLine = node.position ? (node.position.start.line + nodeContent.bodyBegin + line - 1) : "unknown";
               const revisedMessage = e.message.replace(/ \(\d+:\d+\)$/, '') + ` (line: ${actualLine})`;
               throw new Error(`Syntax error in js cell: ${revisedMessage}`);n


### PR DESCRIPTION
Primitive, currently using acorn. We could do a lot more but this
at least gives some feedback if you're writing some code which clearly
won't compile (before this would only happen when we would try to
interpret the bundled code, resulting in a very ugly syntax error).

This also paves the way towards #255.
